### PR TITLE
Cleanup

### DIFF
--- a/rviz_tactile_plugins/CMakeLists.txt
+++ b/rviz_tactile_plugins/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(tactile_filters REQUIRED)
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES agni_tf_tools
-#  CATKIN_DEPENDS other_catkin_pkg
+CATKIN_DEPENDS rviz tactile_msgs
 #  DEPENDS system_lib
 )
 

--- a/rviz_tactile_plugins/package.xml
+++ b/rviz_tactile_plugins/package.xml
@@ -4,7 +4,7 @@
   <version>0.1.0</version>
   <description>rviz tactile plugins</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
@@ -34,7 +34,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <!-- Use build_depend for packages required at compile time: -->
-  <build_depend>cmake_modules</build_depend>
   <build_depend>rviz</build_depend>
   <build_depend>urdf_tactile</build_depend>
   <build_depend>tactile_msgs</build_depend>

--- a/tactile_calibration/tactile_calibration_tools/CMakeLists.txt
+++ b/tactile_calibration/tactile_calibration_tools/CMakeLists.txt
@@ -15,82 +15,8 @@ find_package(catkin REQUIRED COMPONENTS
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
-# find_package(python-yaml REQUIRED)
-# find_package(python-numpy REQUIRED)
-# find_package(pwlf REQUIRED)
 
 catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a exec_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   tactile_msgs
-# )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
 
 ###################################
 ## catkin specific configuration ##
@@ -107,52 +33,6 @@ catkin_package(
 CATKIN_DEPENDS tactile_msgs
 #  DEPENDS python-yaml python-numpy pwlf
 )
-
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-include_directories(
-# include
-  ${catkin_INCLUDE_DIRS}
-# TODO: Check names of system library include directories (pwlf)
-  ${pwlf_INCLUDE_DIRS}
-)
-
-## Declare a C++ library
-# add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/tactile_calibration_tools.cpp
-# )
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/tactile_calibration_tools_node.cpp)
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(${PROJECT_NAME}_node
-#   ${catkin_LIBRARIES}
-#   ${python-yaml_LIBRARIES}
-#   ${python-numpy_LIBRARIES}
-#   ${pwlf_LIBRARIES}
-# )
 
 #############
 ## Install ##

--- a/tactile_calibration/tactile_calibration_tools/CMakeLists.txt
+++ b/tactile_calibration/tactile_calibration_tools/CMakeLists.txt
@@ -104,7 +104,7 @@ catkin_python_setup()
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES tactile_calibration_tools
-#  CATKIN_DEPENDS rosbag rospy tactile_msgs
+CATKIN_DEPENDS tactile_msgs
 #  DEPENDS python-yaml python-numpy pwlf
 )
 

--- a/tactile_calibration/tactile_calibration_tools/README.md
+++ b/tactile_calibration/tactile_calibration_tools/README.md
@@ -8,29 +8,29 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
 
 This toolbox contains 2 command line applications, a recorder and a generator
 
-## Recorder 
+## Recorder
 
 The recorder is a helper to record a raw and a reference signal in a specific calib bagfile to be later calibrated through the generator.
 It is recommended to provide reference calibration information (see options in usage) to directly save a calibrated reference (for instance in Newton)
 
 It can record one or more channel in a row.
-A tare is of the reference is done at start of the application unless disabled.
+A tare of the reference is done at start of the application unless disabled.
 The same tare is re-used for all the acquired channels.
-If a same channel is recorded twice during a recording session, the previous data is moved to an "old" folder.
+If the same channel is recorded twice during a recording session, the previous data is moved to an "old" folder.
 
 ## Generator
 
-The gerenator basically extracts a Piece Wise Linear (PWL) calibration mapping from a dataset composed of raw values of a data channel 
+The generator basically extracts a Piece Wise Linear (PWL) calibration mapping from a dataset composed of raw values of a data channel
 and corresponding ref values (of a calibration tool) while pressing/releasing the data channel to be calibrated.
 The PWL mapping is computed by the library pwlf  https://github.com/cjekel/piecewise_linear_fit_py that must be installed in the system (see Requirements)
 
-The default data expected is in form of a rosbag file with a name "calib_##_<datetime>.bag" containing raw values at channel 0 of a tactile_msgs and ref values at channel 1. 
+The default data expected is in form of a rosbag file with a name "calib_##_<datetime>.bag" containing raw values at channel 0 of a tactile_msgs and ref values at channel 1.
 The number in the filename will be extracted to serve as calibrated channel index in the mapping unless a different number is provided at command line.
 However, the application can handle any bagfile containing a tactile_msgs, at any topic name and at any raw/ref channel indices provided correct options are given.
 A special input permit to process all calib_## files in a folder.
 
 The output is a mapping.yaml file that will be merged with any existing/provided filename, and will replace calibration for duplicate channel index with existing entries.
-single calib mapping.yaml (previous format) will be converted to the multi calib calibration format before merging
+Single-calib mapping.yaml (previous format) will be converted to the multi-calib calibration format before merging.
 
 # Requirements
 
@@ -38,13 +38,13 @@ single calib mapping.yaml (previous format) will be converted to the multi calib
 
 works only in python2.7 due to ros in melodic not supporting python3 (rospkg)
 
-* pwlf library 
- 
+* pwlf library
+
 pip install pwlf
 
 pwlf is compatible with Python2.7 but requires some more recent numpy than the system in Ubuntu xenial, ensure you have more recent one.
 
-# Usage of the recorder 
+# Usage of the recorder
 
 rosrun tactile_calibration_tools record_calib.py <topic> <ref_channel>
 
@@ -59,13 +59,13 @@ usage: record_calib.py [-h] [--ref_topic REF_TOPIC]
                        raw_topic ref_channel
 
 ## required arguments:
- 
+
 * raw_topic           topic where the data channel and optionally reference channel is
 * ref_channel         index where the reference channel is in the raw_topic, or in the ref_topic if provided.
 
 ## optional arguments:
 
-* --data_channel <DATA_CHANNEL> [<DATA_CHANNEL2> [...]] : index (or space-separated indices) of the data channel to calibrate 
+* --data_channel <DATA_CHANNEL> [<DATA_CHANNEL2> [...]] : index (or space-separated indices) of the data channel to calibrate
     (if not provided in the bagfile name, or if one wants to change the default channel 0)
 * --detect_threshold <DETECT_THRESHOLD> : change the default detection threshold for selecting a cell
 * --ref_topic <REF_TOPIC> : topic where the reference channel is if different from raw_topic (data of raw and ref topic will be synchronized)
@@ -81,7 +81,7 @@ usage: record_calib.py [-h] [--ref_topic REF_TOPIC]
 
 # Usage of the generator
 
-rosrun tactile_calibration_tools generate_calib.py <bagfilename> <topic> 
+rosrun tactile_calibration_tools generate_calib.py <bagfilename> <topic>
 
 usage: generate_calib.py [-h] [--mapping_file MAPPING_FILE]
                          [--no_extrapolation] [--data_channel DATA_CHANNEL]
@@ -94,8 +94,8 @@ usage: generate_calib.py [-h] [--mapping_file MAPPING_FILE]
                          bagfilename topic
 
 ## required arguments:
- 
-* bagfilename           bag filename to open. 
+
+* bagfilename           bag filename to open.
                         If filename is ofr the form "calib_##_*.bag", ## being a number, the number will be extracted to become the calibrated cell index in the output mapping
                         If filename ends with calib_# (with the sharp), all calib_##_*.bag files in the given folder will be processed
                            if several files are available for a same channel, the latest in recording date will be used.
@@ -115,4 +115,3 @@ usage: generate_calib.py [-h] [--mapping_file MAPPING_FILE]
 * --output_csv : enable output of a lookup.csv with the resulting mapping (for debugging)
 * --input_resolution <INPUT_RESOLUTION> : input resolution in bits (default is 12)
 * --segments <SEGMENTS> : number of segments for piece-wise-linear mapping (default is 2)
-

--- a/tactile_calibration/tactile_calibration_tools/package.xml
+++ b/tactile_calibration/tactile_calibration_tools/package.xml
@@ -10,45 +10,15 @@
 
   <author email="gwalck@techfak.uni-bielefeld.de">Guillaume Walck</author> -->
 
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>pwlf</build_depend>
-  <build_depend>rosbag</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>tactile_msgs</build_depend>
-  <build_export_depend>pwlf</build_export_depend>
-  <build_export_depend>rosbag</build_export_depend>
-  <build_export_depend>rospy</build_export_depend>
-  <build_export_depend>tactile_msgs</build_export_depend>
-  <exec_depend>pwlf</exec_depend>
+  <depend>rosbag</depend>
+  <depend>rospy</depend>
+  <depend>tactile_msgs</depend>
   <exec_depend>python-numpy</exec_depend>
   <exec_depend>python-yaml</exec_depend>
-  <exec_depend>rosbag</exec_depend>
-  <exec_depend>rospy</exec_depend>
-  <exec_depend>tactile_msgs</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->
-
   </export>
 </package>

--- a/tactile_calibration/tactile_calibration_tools/src/tactile_calibration_tools/calibration_utils.py
+++ b/tactile_calibration/tactile_calibration_tools/src/tactile_calibration_tools/calibration_utils.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 import matplotlib.pyplot as plt
 from datetime import datetime
 import os
-#pip install pwlf
 import pwlf
 
 
@@ -72,9 +71,9 @@ def detect_channel_press(raw_previous_vec, raw_vec, ref_channel, detect_threshol
     if len(raw_previous_vec) == len (raw_vec):
         absdiff = np.fabs(np.array(raw_vec)-np.array(raw_previous_vec))
         idx_above_thresh = np.where(absdiff > detect_threshold)
-        if len(idx_above_thresh[0]):  # anything above threshold  
+        if len(idx_above_thresh[0]):  # anything above threshold
             if len(idx_above_thresh[0])==1 and not (ref_channel in idx_above_thresh[0]):  # one channel pressed that is not the ref
-                detected_channel =  idx_above_thresh[0][0]  
+                detected_channel =  idx_above_thresh[0][0]
             if len(idx_above_thresh[0])==2:  # 2 channels pressed
                 if ref_channel in idx_above_thresh[0]:  # the reference was pressed too
                     for channel in idx_above_thresh[0]:  # find the one that is not the ref
@@ -102,7 +101,7 @@ def compute_tare(data, flatness_threshold=None):
         if end_flat_range is not None:
             # we found a certain zone of flatness at the beginning of the data
             tare = np.mean(data[0:end_flat_range])
-        else: 
+        else:
             print "The ref is too flat, are you sure the correct channel was selected ?"
             tare = None
     else: # not extracting a flat, part, just using the whole vector
@@ -111,7 +110,7 @@ def compute_tare(data, flatness_threshold=None):
 
 
 def calibrate_affine(raw, a, b):
-    # affine calibration 
+    # affine calibration
     return a * raw + b
 
 def calibrate_ref(ref_vec, ref_ratio, ref_offset, user_tare=None, flatness_threshold=0.3, user_is_raw=False):
@@ -162,7 +161,7 @@ def get_push_release(raw, ref, change_detect_threshold, doplot=False):
     if doplot:
         plt.figure(1)
         plt.clf()
-       
+
         plt.subplot(211)             # the first subplot in the first figure
         plt.title('Detection of Push / Release')
         plt.plot(range(len(smooth_raw)),smooth_raw, 'g-', lw=1) # smooth raw values
@@ -171,14 +170,14 @@ def get_push_release(raw, ref, change_detect_threshold, doplot=False):
         plt.plot(range(len(vel)), vel*50, 'k-', lw=1) # velocity scaled up
         plt.ylabel('Raw / derivative of Raw (x50)')
         plt.legend(["Channel","Pushing", "Releasing", "Vel"])
-        
+
         plt.subplot(212)             # the second subplot in the first figure
         plt.plot(range(len(ref)), ref, 'm-', lw=1)
         plt.xlabel('Samples')
         plt.ylabel('Ref')
         plt.legend(["Reference"])
         plt.show(block = False)
-    
+
     return [inc_idx, dec_idx]
 
 def get_push_release_from_msgs(msgs, change_detect_threshold, doplot=False):
@@ -233,8 +232,8 @@ def generate_lookup(raw, ref, inc_idx, dec_idx, input_range_max, doplot=False):
         plt.clf()
         plt.plot(x_inc, y_inc, 'mx')
         plt.plot(x_dec, y_dec, 'c+')
-        
-        plt.title('Lookup data for Push and Release') 
+
+        plt.title('Lookup data for Push and Release')
         plt.ylabel('Ref')
         plt.xlabel('Raw')
         plt.legend(["Pushing","Releasing"])
@@ -258,7 +257,7 @@ def get_later_date(old, new):
         try:
             datetime_obj_old = datetime.strptime(datetime_str_old, "%Y-%m-%d-%H-%M-%S")
             datetime_obj_new = datetime.strptime(datetime_str_new, "%Y-%m-%d-%H-%M-%S")
-            
+
             if datetime_obj_new > datetime_obj_old:
                 return new
             else:
@@ -374,10 +373,10 @@ def generate_mapping_pwl(x, y, input_range_max, calib_channel, seg=4, no_extrapo
         y_hat = pwlf_result.predict(x_hat)
 
         plt.figure()
-        plt.clf() 
+        plt.clf()
         plt.plot(xs, ys, 'o')
         plt.plot(x_hat, y_hat, '-')
-        plt.title('Piece-wise linear mapping channel '+ str(calib_channel)) 
+        plt.title('Piece-wise linear mapping channel '+ str(calib_channel))
         plt.ylabel('Ref')
         plt.xlabel('Raw')
         plt.legend(["Pushing data", "PWL Mapping"])
@@ -410,4 +409,3 @@ def generate_mapping_pwl(x, y, input_range_max, calib_channel, seg=4, no_extrapo
     else:
         mapping_dict = mapping_dict_tmp
     return mapping_dict
-

--- a/tactile_calibration/tactile_calibration_tools/src/tactile_calibration_tools/calibration_utils.py
+++ b/tactile_calibration/tactile_calibration_tools/src/tactile_calibration_tools/calibration_utils.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 import matplotlib.pyplot as plt
 from datetime import datetime
 import os
-import pwlf
 
 
 def find_inflection_index(x, change_detection_threshold=4):
@@ -354,14 +353,16 @@ def read_calib(bagfilename, user_topic, data_channel, ref_channel, input_range_m
     return [sensor_name, ref_raw_vec, raw_vec]
 
 def generate_mapping_pwl(x, y, input_range_max, calib_channel, seg=4, no_extrapolation=False, doplot=False):
+    try:
+        import pwlf
+    except ImportError as e:
+        e.args = (e.args[0] + '. Ensure that it is installed according to the instructions here: \n' \
+                  '  https://github.com/cjekel/piecewise_linear_fit_py#installation',)
+        raise
 
     xs = np.array(x)
     ys = np.array(y)
     #ys = smooth(y_inc,100)
-
-    # solution with pwlf 1  https://pypi.org/project/pwlf/   # not available in package manager
-    # Installing collected packages: numpy, scipy, pyDOE, pwlf
-    # Successfully installed numpy-1.16.6 pwlf-2.0.3 pyDOE-0.3.8 scipy-1.2.3
 
     pwlf_result = pwlf.PiecewiseLinFit(xs, ys)
     # request a fit with n points

--- a/tactile_calibration/tactile_state_calibrator/CMakeLists.txt
+++ b/tactile_calibration/tactile_state_calibrator/CMakeLists.txt
@@ -1,14 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tactile_state_calibrator)
 
-find_package(catkin REQUIRED COMPONENTS roscpp tactile_msgs
-)
+find_package(catkin REQUIRED COMPONENTS roscpp tactile_msgs)
 find_package(tactile_filters REQUIRED)
 
 include(FindPkgConfig)
-pkg_search_module(YAML yaml-cpp)
-
-
+pkg_search_module(YAML REQUIRED yaml-cpp)
 
 catkin_package(
 #  INCLUDE_DIRS include
@@ -17,16 +14,10 @@ catkin_package(
 #  DEPENDS
 )
 
-if(YAML_FOUND)
-  add_definitions(-DHAVE_YAML)
-  ## Specify additional locations of header files
-  include_directories(${YAML_INCLUDE_DIRS})
-endif(YAML_FOUND)
-
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${YAML_INCLUDE_DIRS})
 
 add_executable(${PROJECT_NAME} src/tactile_state_calibrator.cpp)
-target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} tactile_filters PRIVATE ${YAML_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} tactile_filters ${YAML_LIBRARIES})
 add_definitions(-std=c++11)
 # only works since cmake 3.1
 # target_compile_features(${PROJECT_NAME} PUBLIC cxx_auto_type)

--- a/tactile_calibration/tactile_state_calibrator/CMakeLists.txt
+++ b/tactile_calibration/tactile_state_calibrator/CMakeLists.txt
@@ -18,9 +18,7 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${YAML_INCLUDE_DIRS})
 
 add_executable(${PROJECT_NAME} src/tactile_state_calibrator.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} tactile_filters ${YAML_LIBRARIES})
-add_definitions(-std=c++11)
-# only works since cmake 3.1
-# target_compile_features(${PROJECT_NAME} PUBLIC cxx_auto_type)
+target_compile_options(${PROJECT_NAME} PRIVATE -std=c++11)
 
 install(TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/tactile_calibration/tactile_state_calibrator/CMakeLists.txt
+++ b/tactile_calibration/tactile_state_calibrator/CMakeLists.txt
@@ -4,17 +4,17 @@ project(tactile_state_calibrator)
 find_package(catkin REQUIRED COMPONENTS roscpp tactile_msgs)
 find_package(tactile_filters REQUIRED)
 
-include(FindPkgConfig)
+find_package(PkgConfig REQUIRED)
 pkg_search_module(YAML REQUIRED yaml-cpp)
 
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES
-#  CATKIN_DEPENDS tactile_msgs sensor_msgs
+CATKIN_DEPENDS tactile_msgs roscpp
 #  DEPENDS
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${YAML_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS} ${YAML_INCLUDE_DIRS})
 
 add_executable(${PROJECT_NAME} src/tactile_state_calibrator.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} tactile_filters ${YAML_LIBRARIES})

--- a/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
+++ b/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
@@ -276,7 +276,7 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
     if (single_calib_ == nullptr && calibs_.size()==0)
     {
       if (verbose>1)
-        ROS_INFO_STREAM(" calibs or single_calib empty" );
+        ROS_INFO_STREAM(" calibs and single_calib empty" );
       throw ("unable to create PieceWiseLinearCalib");
       return;
     }

--- a/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
+++ b/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
@@ -148,7 +148,6 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
       switch( yaml_calibs.Type() )
       {
         case YAML::NodeType::Sequence: // a sequence of calibration configuration
-        {
           ROS_DEBUG_NAMED(detail, "found calibs");
           // for each calib
           for(YAML::const_iterator calib_it=yaml_calibs.begin(); calib_it!=yaml_calibs.end(); ++calib_it)
@@ -172,7 +171,6 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
             switch (calib_type)
             {
               case TactileStateCalibrator::calib_type::PWL:
-              {
                 // search for mapping values 
                 // check if the sequence is defining calibration mappings
                 if (yaml_calib["values"])
@@ -190,7 +188,7 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
                 else
                   ROS_ERROR("Values not found but Piece Wise Linear requires values");
                 break;
-              }
+
               case TactileStateCalibrator::calib_type::RAW:
               default:
                 calib_ptr.reset();
@@ -239,12 +237,11 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
             fill_calibs(idx_to_calib_map);  
           }
           break;
-        }
+
         case YAML::NodeType::Map: // wrong type
-        {
           ROS_FATAL("Wrong format, sequence calibration configuration expected");
           break;
-        }
+
         default:
           break;
       }

--- a/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
+++ b/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
@@ -23,7 +23,7 @@ TactileStateCalibrator::TactileStateCalibrator(const std::string calib_filename)
   init(calib_filename);
 }
 
-bool TactileStateCalibrator::fill_calibs(std::map<int, tactile::Calibration*> &map)
+bool TactileStateCalibrator::fill_calibs(const std::map<unsigned int, std::shared_ptr<Calibration> > &map)
 {
   // check for the smallest and largest key
   unsigned int max_key = 0, min_key = std::numeric_limits<unsigned int>::max();
@@ -62,7 +62,8 @@ bool TactileStateCalibrator::fill_calibs(std::map<int, tactile::Calibration*> &m
   return false;
 }
 
-bool TactileStateCalibrator::extract_idx_range(const YAML::Node &node, std::map<int, tactile::Calibration*> &map, tactile::Calibration* p)
+bool TactileStateCalibrator::extract_idx_range(const YAML::Node &node, std::map<unsigned int, std::shared_ptr<Calibration> > &map,
+                                               const std::shared_ptr<Calibration> &calib)
 {
   if (node.Type() == YAML::NodeType::Sequence)
   {
@@ -93,9 +94,9 @@ bool TactileStateCalibrator::extract_idx_range(const YAML::Node &node, std::map<
               if (verbose>1)
                 ROS_INFO_STREAM("  index range valid" );
               // add the range to the idx_map and associate it to the calibration pointer
-              for (unsigned int i = idx_ranges[0]; i <= idx_ranges[1];++i) 
+              for (int i = idx_ranges[0]; i <= idx_ranges[1]; ++i)
               {
-                map[i] = p;
+                map[i] = calib;
               }
               if (verbose>1)
                 ROS_INFO_STREAM("  added index in range [" <<  idx_ranges[0] << ", " << idx_ranges[1] << "]");
@@ -119,13 +120,10 @@ bool TactileStateCalibrator::extract_idx_range(const YAML::Node &node, std::map<
             ROS_INFO_STREAM("  found a scalar" );
           const YAML::Node yaml_scal = (*idx_range_it);
           if (yaml_scal.as<int>() >= 0)
+            map[yaml_scal.as<unsigned int>()] = calib;
+          else // negative value == apply to all == single calib
           {
-            map[yaml_scal.as<int>()] = p;
-          }
-          else
-          {
-            // all = single calib
-            single_calib_ = p;
+            single_calib_ = calib;
             break;
           }
         }
@@ -152,9 +150,9 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
     if (yaml_node["calib"])
     {
       const YAML::Node yaml_calibs = yaml_node["calib"];
-      std::map<int, tactile::Calibration *> idx_to_calib_map;
-      tactile::Calibration *calib_ptr = nullptr;
-      single_calib_ = nullptr;
+      std::map<unsigned int, std::shared_ptr<tactile::Calibration>> idx_to_calib_map;
+      std::shared_ptr<tactile::Calibration> calib_ptr;
+      single_calib_.reset();
       calibs_.clear();
 
       switch( yaml_calibs.Type() )
@@ -194,7 +192,7 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
                   {
                     if (verbose>0)
                       ROS_INFO_STREAM(" loading map" );
-                    calib_ptr =  new PieceWiseLinearCalib(PieceWiseLinearCalib::load(yaml_calib["values"]));
+                    calib_ptr = std::make_shared<PieceWiseLinearCalib>(PieceWiseLinearCalib::load(yaml_calib["values"]));
                     if (verbose>0)
                     {
                       ROS_INFO_STREAM (" input range is :" << calib_ptr->input_range());
@@ -210,7 +208,7 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
               }
               case TactileStateCalibrator::calib_type::RAW:
               default:
-                calib_ptr = nullptr;
+                calib_ptr.reset();
             }
 
             // extract range
@@ -221,7 +219,7 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
               if(extract_idx_range(yaml_calib["idx_range"], idx_to_calib_map, calib_ptr))
               {
                 // check the result
-                if (single_calib_ == nullptr) 
+                if (!single_calib_)
                 {
                   if (idx_to_calib_map.size()==0)
                   {
@@ -250,7 +248,7 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
           }
 
           // if required, prepare the calibs_ vector from the idx_to_calib map
-          if (single_calib_ == nullptr && idx_to_calib_map.size()>0)
+          if (!single_calib_ && idx_to_calib_map.size()>0)
           {
             // fill calibs_
             if (verbose>1)
@@ -272,9 +270,9 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
     {
       if (verbose>1)
         ROS_INFO("found a single map");
-      single_calib_ = new PieceWiseLinearCalib(PieceWiseLinearCalib::load(yaml_node));
+      single_calib_ = std::make_shared<PieceWiseLinearCalib>(PieceWiseLinearCalib::load(yaml_node));
     }
-    if (single_calib_ == nullptr && calibs_.size()==0)
+    if (!single_calib_ && calibs_.size()==0)
     {
       if (verbose>1)
         ROS_INFO_STREAM(" calibs and single_calib empty" );
@@ -297,12 +295,12 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
   ROS_INFO("tactile_state_calibrator initialized");
 }
 
-float TactileStateCalibrator::map(float val, tactile::Calibration *c)
+float TactileStateCalibrator::map(float val, const std::shared_ptr<Calibration> &calib)
 {
-  if (c== nullptr)
+  if (!calib)
     return val;
   else
-    return c->map(val);
+    return calib->map(val);
 }
 
 
@@ -314,11 +312,11 @@ void TactileStateCalibrator::tactile_state_cb(const tactile_msgs::TactileStateCo
   for (size_t i = 0; i < msg->sensors.size(); ++i)
   {
     // if one calibmap for this sensor, 
-    if (calibs_.size() == 0 && single_calib_ != nullptr)
+    if (calibs_.size() == 0 && single_calib_)
     {
       // same function as in the previous glove console
       std::transform(msg->sensors[i].values.begin(), msg->sensors[i].values.end(), out_msg.sensors[i].values.begin(),
-                     std::bind(&tactile::Calibration::map, single_calib_, std::placeholders::_1));
+                     std::bind(&tactile::Calibration::map, single_calib_.get(), std::placeholders::_1));
     }
     else // if more than one calibmap for this sensor
     {
@@ -345,14 +343,8 @@ TactileStateCalibrator::~TactileStateCalibrator()
   // unregister
   tactile_sub_.shutdown();
   // cleanup
-  if (calibs_.size())
-  {
-    for (auto p : calibs_)
-    {
-      delete p;
-    } 
-    calibs_.clear();
-  }
+  calibs_.clear();
+  single_calib_.reset();
 }
 
 int main(int argc, char **argv)

--- a/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
+++ b/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
@@ -69,11 +69,11 @@ bool TactileStateCalibrator::extract_idx_range(const YAML::Node &node, std::map<
   {
     if (verbose>1)
       ROS_INFO_STREAM(" found an index range" );
-    std::vector<unsigned int> idx_ranges;
+    std::vector<unsigned int> idx_range;
     // Break from loop as soon as single_calib_ was configured to handle all taxels
     for(YAML::const_iterator idx_range_it=node.begin(); idx_range_it!=node.end() && !single_calib_; ++idx_range_it)
     {
-      idx_ranges.clear();
+      idx_range.clear();
       switch ((*idx_range_it).Type())
       {
         case YAML::NodeType::Sequence:
@@ -83,24 +83,24 @@ bool TactileStateCalibrator::extract_idx_range(const YAML::Node &node, std::map<
           const YAML::Node yaml_vec = (*idx_range_it);
           if (verbose>1)
             ROS_INFO_STREAM("  extract sequence" );
-          idx_ranges = yaml_vec.as<std::vector<unsigned int>>();
+          idx_range = yaml_vec.as<std::vector<unsigned int>>();
           // must be pairs
-          if(idx_ranges.size() == 2)
+          if(idx_range.size() == 2)
           {
             if (verbose>1)
               ROS_INFO_STREAM("  found size 2" );
             // check the start and end are valid
-            if  (idx_ranges[0] < idx_ranges[1] && idx_ranges[0] >= 0)
+            if  (idx_range[0] < idx_range[1] && idx_range[0] >= 0)
             {
               if (verbose>1)
                 ROS_INFO_STREAM("  index range valid" );
               // add the range to the idx_map and associate it to the calibration pointer
-              for (unsigned int i = idx_ranges[0]; i <= idx_ranges[1]; ++i)
+              for (unsigned int i = idx_range[0]; i <= idx_range[1]; ++i)
               {
                 map[i] = calib;
               }
               if (verbose>1)
-                ROS_INFO_STREAM("  added index in range [" <<  idx_ranges[0] << ", " << idx_ranges[1] << "]");
+                ROS_INFO_STREAM("  added index in range [" <<  idx_range[0] << ", " << idx_range[1] << "]");
             }
             else
             {

--- a/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
+++ b/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
@@ -10,10 +10,7 @@
 #include <vector>
 #include <string>
 #include <algorithm>
-#ifdef HAVE_YAML
 #include <yaml-cpp/yaml.h>
-#endif
-
 
 using namespace tactile;
 
@@ -150,7 +147,6 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
   if (!calib_filename.empty())
   {
     calibs_.clear();
-#ifdef HAVE_YAML
     const YAML::Node yaml_node = YAML::LoadFile(calib_filename);
     if (yaml_node["calib"])
     {
@@ -277,9 +273,6 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
         ROS_INFO("found a single map");
       single_calib_ = new PieceWiseLinearCalib(PieceWiseLinearCalib::load(yaml_node));
     }
-#else
-    single_calib_ = new PieceWiseLinearCalib(PieceWiseLinearCalib::load(calib_filename));
-#endif
     if (single_calib_ == nullptr && calibs_.size()==0)
     {
       if (verbose>1)

--- a/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
+++ b/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
@@ -69,7 +69,7 @@ bool TactileStateCalibrator::extract_idx_range(const YAML::Node &node, std::map<
   {
     if (verbose>1)
       ROS_INFO_STREAM(" found an index range" );
-    std::vector<int> idx_ranges;
+    std::vector<unsigned int> idx_ranges;
     // Break from loop as soon as single_calib_ was configured to handle all taxels
     for(YAML::const_iterator idx_range_it=node.begin(); idx_range_it!=node.end() && !single_calib_; ++idx_range_it)
     {
@@ -83,7 +83,7 @@ bool TactileStateCalibrator::extract_idx_range(const YAML::Node &node, std::map<
           const YAML::Node yaml_vec = (*idx_range_it);
           if (verbose>1)
             ROS_INFO_STREAM("  extract sequence" );
-          idx_ranges = yaml_vec.as<std::vector<int>>();
+          idx_ranges = yaml_vec.as<std::vector<unsigned int>>();
           // must be pairs
           if(idx_ranges.size() == 2)
           {
@@ -95,7 +95,7 @@ bool TactileStateCalibrator::extract_idx_range(const YAML::Node &node, std::map<
               if (verbose>1)
                 ROS_INFO_STREAM("  index range valid" );
               // add the range to the idx_map and associate it to the calibration pointer
-              for (int i = idx_ranges[0]; i <= idx_ranges[1]; ++i)
+              for (unsigned int i = idx_ranges[0]; i <= idx_ranges[1]; ++i)
               {
                 map[i] = calib;
               }

--- a/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
+++ b/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <exception>
 #include <yaml-cpp/yaml.h>
 
 using namespace tactile;
@@ -225,7 +226,7 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
                   if (idx_to_calib_map.size()==0)
                   {
                     ROS_ERROR(" No calibration assigned, something went wrong");
-                    throw ("No calibration assigned, something went wrong");
+                    throw std::runtime_error("No calibration assigned, something went wrong");
                     return;
                   }
                 }
@@ -277,13 +278,13 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
     {
       if (verbose>1)
         ROS_INFO_STREAM(" calibs and single_calib empty" );
-      throw ("unable to create PieceWiseLinearCalib");
+      throw std::runtime_error("unable to create PieceWiseLinearCalib");
       return;
     }
   }
   else
   {
-    throw ("calibration file cannot be empty");
+    throw std::runtime_error("calibration file cannot be empty");
     return;
   }
   if (verbose>0)

--- a/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
+++ b/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
@@ -124,7 +124,7 @@ bool TactileStateCalibrator::extract_idx_range(const YAML::Node &node, std::map<
           else // negative value == apply to all == single calib
           {
             single_calib_ = calib;
-            break;
+            break; // BUG?: The break applies to the switch, but should apply to the for loop here?
           }
         }
         default:
@@ -166,7 +166,7 @@ void TactileStateCalibrator::init(const std::string &calib_filename)
           {
             YAML::Node yaml_calib = *calib_it;
             // extract sensor name
-            std::string sensor_name = "None";
+            std::string sensor_name = "None";  // TODO: sensor_name is not yet used.
             if (yaml_calib["sensor_name"])
               sensor_name = yaml_calib["sensor_name"].as<std::string>();
 

--- a/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
+++ b/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.cpp
@@ -70,7 +70,8 @@ bool TactileStateCalibrator::extract_idx_range(const YAML::Node &node, std::map<
     if (verbose>1)
       ROS_INFO_STREAM(" found an index range" );
     std::vector<int> idx_ranges;
-    for(YAML::const_iterator idx_range_it=node.begin(); idx_range_it!=node.end(); ++idx_range_it)
+    // Break from loop as soon as single_calib_ was configured to handle all taxels
+    for(YAML::const_iterator idx_range_it=node.begin(); idx_range_it!=node.end() && !single_calib_; ++idx_range_it)
     {
       idx_ranges.clear();
       switch ((*idx_range_it).Type())
@@ -122,10 +123,7 @@ bool TactileStateCalibrator::extract_idx_range(const YAML::Node &node, std::map<
           if (yaml_scal.as<int>() >= 0)
             map[yaml_scal.as<unsigned int>()] = calib;
           else // negative value == apply to all == single calib
-          {
             single_calib_ = calib;
-            break; // BUG?: The break applies to the switch, but should apply to the for loop here?
-          }
         }
         default:
         break;

--- a/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.h
+++ b/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.h
@@ -10,13 +10,13 @@
 #include <ros/ros.h>
 
 #include <memory>
+#include <string>
+#include <vector>
+
 #include <tactile_msgs/TactileState.h>
 #include <sensor_msgs/ChannelFloat32.h>
 #include <tactile_filters/PieceWiseLinearCalib.h>
 #include <tactile_filters/Calibration.h>
-
-#include <string>
-#include <vector>
 
 class TactileStateCalibrator
 {
@@ -43,11 +43,12 @@ private:
   /**
    * fill calibs_ vector from a map of index
    */
-  bool fill_calibs(std::map<int, tactile::Calibration*> &map);
+  bool fill_calibs(const std::map<unsigned int, std::shared_ptr<tactile::Calibration> > &map);
   /**
-   * extract index of taxels a calib applies to
+   * extract indices of taxels a calib applies to
    */
-  bool extract_idx_range(const YAML::Node &node, std::map<int, tactile::Calibration*> &map, tactile::Calibration* p);
+  bool extract_idx_range(const YAML::Node &node, std::map<unsigned int, std::shared_ptr<tactile::Calibration>> &map,
+                         const std::shared_ptr<tactile::Calibration>& calib);
 
   /**
    * generic tactile callback
@@ -56,8 +57,8 @@ private:
   /**
    * wrapper to call calibration map operator with different calib
    */ 
-  float map(float val, tactile::Calibration *c);
+  float map(float val, const std::shared_ptr<tactile::Calibration>& calib);
   
-  std::vector<tactile::Calibration *> calibs_;
-  tactile::Calibration * single_calib_;
+  std::vector<std::shared_ptr<tactile::Calibration>> calibs_;
+  std::shared_ptr<tactile::Calibration> single_calib_;
 };

--- a/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.h
+++ b/tactile_calibration/tactile_state_calibrator/src/tactile_state_calibrator.h
@@ -54,7 +54,7 @@ private:
    */
   void tactile_state_cb(const tactile_msgs::TactileStateConstPtr& msg);
   /**
-   * wrappwr to call calibration map operator with different calib
+   * wrapper to call calibration map operator with different calib
    */ 
   float map(float val, tactile::Calibration *c);
   

--- a/tactile_merger/CMakeLists.txt
+++ b/tactile_merger/CMakeLists.txt
@@ -10,30 +10,30 @@ find_package(Eigen3 REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-#  CATKIN_DEPENDS other_catkin_pkg
+  CATKIN_DEPENDS tactile_msgs
 #  DEPENDS system_lib
 )
 
 include_directories(
-  include/tactile_merger
+  include
   ${catkin_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIR}
 )
 
-add_library(lib${PROJECT_NAME}
+add_library(${PROJECT_NAME}
   src/taxel.cpp
   src/taxel_group.cpp
   src/merger.cpp
 )
-target_link_libraries(lib${PROJECT_NAME} ${catkin_LIBRARIES} tactile_filters)
-set_target_properties(lib${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} tactile_filters)
+set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 
-add_executable(${PROJECT_NAME} src/merger_node.cpp)
-target_link_libraries(${PROJECT_NAME} lib${PROJECT_NAME})
+add_executable(merger_node src/merger_node.cpp)
+target_link_libraries(merger_node ${PROJECT_NAME})
 
 # Install rules
 install(TARGETS
-  ${PROJECT_NAME} lib${PROJECT_NAME}
+  merger_node ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/tactile_merger/CMakeLists.txt
+++ b/tactile_merger/CMakeLists.txt
@@ -28,12 +28,13 @@ add_library(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} tactile_filters)
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 
-add_executable(merger_node src/merger_node.cpp)
-target_link_libraries(merger_node ${PROJECT_NAME})
+add_executable(${PROJECT_NAME}_node src/merger_node.cpp)
+target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME})
+set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 
 # Install rules
 install(TARGETS
-  merger_node ${PROJECT_NAME}
+  ${PROJECT_NAME}_node ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/tactile_merger/src/merger.cpp
+++ b/tactile_merger/src/merger.cpp
@@ -26,7 +26,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include "merger.h"
+#include <tactile_merger/merger.h>
 #include <tactile_msgs/TactileContacts.h>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/locks.hpp>

--- a/tactile_merger/src/merger_node.cpp
+++ b/tactile_merger/src/merger_node.cpp
@@ -26,7 +26,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include "merger.h"
+#include <tactile_merger/merger.h>
 #include <ros/ros.h>
 #include <tactile_msgs/TactileContacts.h>
 #include <tactile_msgs/TactileState.h>

--- a/tactile_merger/src/taxel.cpp
+++ b/tactile_merger/src/taxel.cpp
@@ -26,7 +26,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include "taxel.h"
+#include <tactile_merger/taxel.h>
 
 namespace tactile {
 

--- a/tactile_merger/src/taxel_group.cpp
+++ b/tactile_merger/src/taxel_group.cpp
@@ -26,7 +26,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include "taxel_group.h"
+#include <tactile_merger/taxel_group.h>
 
 #include <urdf/sensor.h>
 #include <ros/console.h>

--- a/tactile_pcl/CMakeLists.txt
+++ b/tactile_pcl/CMakeLists.txt
@@ -32,72 +32,11 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
 #	INCLUDE_DIRS
 #	LIBRARIES
-#	CATKIN_DEPENDS roscpp std_msgs
+CATKIN_DEPENDS sensor_msgs tactile_msgs
 #	DEPENDS system_lib
 )
 
-###########
-## Build ##
-###########
-
 ## Specify additional locations of header files
-## Your package locations should be listed before other locations
-# include_directories(include)
-include_directories(
-	${catkin_INCLUDE_DIRS}
-)
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(tactile_pcl ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+include_directories(${catkin_INCLUDE_DIRS})
 
 add_subdirectory(src)
-
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
-# install(TARGETS tactile_pcl tactile_pcl_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_tactile_pcl.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/tactile_pcl/src/CMakeLists.txt
+++ b/tactile_pcl/src/CMakeLists.txt
@@ -8,3 +8,10 @@ add_executable(tactile_pcl_node
 target_link_libraries(tactile_pcl_node
 	${catkin_LIBRARIES}
 )
+
+## Mark executables and/or libraries for installation
+install(TARGETS tactile_pcl_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/tactile_state_publisher/CMakeLists.txt
+++ b/tactile_state_publisher/CMakeLists.txt
@@ -9,11 +9,11 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES
-#  CATKIN_DEPENDS tactile_msgs sensor_msgs
+CATKIN_DEPENDS tactile_msgs
 #  DEPENDS
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS})
 
 add_executable(${PROJECT_NAME} src/tactile_state_publisher.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/urdf_tactile/CMakeLists.txt
+++ b/urdf_tactile/CMakeLists.txt
@@ -32,7 +32,6 @@ catkin_package(
 ## sub dir ##
 #############
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
-link_directories(${Boost_LIBRARY_DIRS})
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 file(GLOB_RECURSE PROJECT_INCLUDES *.h)

--- a/urdf_tactile/package.xml
+++ b/urdf_tactile/package.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>urdf_tactile</name>
   <version>0.1.0</version>
   <description>handle tactile sensor descriptions in URDF</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
@@ -33,12 +33,8 @@
   <!-- Dependencies can be catkin packages or system dependencies -->
   <buildtool_depend>catkin</buildtool_depend>
 
-  <!-- Use build_depend for packages required at compile time: -->
-  <build_depend>cmake_modules</build_depend>
-  <build_depend>urdf</build_depend>
-
-  <!-- Use run_depend for packages you need at runtime: -->
-  <run_depend>urdf</run_depend>
+  <depend>urdf</depend>
+  <depend>pluginlib</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/urdf_tactile/test/CMakeLists.txt
+++ b/urdf_tactile/test/CMakeLists.txt
@@ -1,6 +1,5 @@
 find_package(Boost REQUIRED unit_test_framework)
 include_directories(${Boost_INCLUDE_DIR})
-link_directories(${Boost_LIBRARY_DIRS})
 
 # unit tests
 add_executable(test_parser parser.cpp)


### PR DESCRIPTION
Dear @guihomework,
Trying to understand `pwlf`, I started first looking into your multi-calib commits. I have collected some required changes in this PR.
Please have a look into the individual commits and the review comments I (will) add via github.

As far as I understand the basic idea was to allow different calibrations for different taxel subsets, which will be very useful.
I have some suggestions regarding the semantics and yaml syntax to further improve:
* Why do you use the main key `calib`? Will there be any other key? My suggestion is to drop it and just use a sequence.
* The `sensor_name` is not used yet. Do we need it at all? Is that just for documentation?
* As far as I understand, `single_calib_` is used for all taxels if:
  * there is no multi-calib given at all
  * there is no `idx_range` given for any sequence item
  * there is a single, `negative` idx specified in `idx_range` for any sequence item
    I suggest to drop this last condition or replace it by `idx_range: default`. 
    My key suggestion is to use this as the default (or fallback) calib, if nothing more specific was defined for a taxel. Currently, `single_calib_` is only actually used when `calib_` is empty and calib_ is only used if it defines calibs for all taxel inputs.
    If we agree on this new semantics, I would cleanup the code some more towards this direction.

Hence, an example yaml config would look like this:
```yaml
  - sensor_name: board0
    type: PWL
    idx_range: [[0, 50], [51,90]]
    values:
      0:    0
      1024: 10
      4095: 4095
  - sensor_name: board0
    type: PWL
    idx_range: default
    values:
      0:    -3.0
      4095: -5.0
```
What do you think?