### PR TITLE
Support for a non-clustering mode in tactile_merger

### DIFF
--- a/tactile_merger/include/tactile_merger/merger.h
+++ b/tactile_merger/include/tactile_merger/merger.h
@@ -42,8 +42,8 @@ public:
 	template <typename Iterator>
 	void update(const ros::Time &stamp, const std::string &channel,
 	            Iterator begin, Iterator end);
-	tactile_msgs::TactileContacts getAverageContacts();
-	tactile_msgs::TactileContacts getAllContacts();
+	tactile_msgs::TactileContacts getGroupContacts();
+	tactile_msgs::TactileContacts getAllTaxelContacts();
 
 private:
 	struct GroupData;

--- a/tactile_merger/include/tactile_merger/merger.h
+++ b/tactile_merger/include/tactile_merger/merger.h
@@ -42,7 +42,7 @@ public:
 	template <typename Iterator>
 	void update(const ros::Time &stamp, const std::string &channel,
 	            Iterator begin, Iterator end);
-	tactile_msgs::TactileContacts getGroupContacts();
+	tactile_msgs::TactileContacts getGroupAveragedContacts();
 	tactile_msgs::TactileContacts getAllTaxelContacts();
 
 private:

--- a/tactile_merger/include/tactile_merger/merger.h
+++ b/tactile_merger/include/tactile_merger/merger.h
@@ -42,7 +42,8 @@ public:
 	template <typename Iterator>
 	void update(const ros::Time &stamp, const std::string &channel,
 	            Iterator begin, Iterator end);
-	tactile_msgs::TactileContacts getContacts();
+	tactile_msgs::TactileContacts getAverageContacts();
+	tactile_msgs::TactileContacts getAllContacts();
 
 private:
 	struct GroupData;

--- a/tactile_merger/include/tactile_merger/taxel_group.h
+++ b/tactile_merger/include/tactile_merger/taxel_group.h
@@ -81,7 +81,7 @@ private:
 	SensorToTaxelMapping mappings_;
 	/// conversion from eigen pos, normal, amplitude to contact
 	void toContact(tactile_msgs::TactileContact &contact, const Eigen::Vector3d &pos,
-	               const Eigen::Vector3d &normal, const float &force_amplitude, const int i=-1);
+	               const Eigen::Vector3d &normal, const double force_amplitude);
 };
 
 } // namespace tactile

--- a/tactile_merger/include/tactile_merger/taxel_group.h
+++ b/tactile_merger/include/tactile_merger/taxel_group.h
@@ -30,6 +30,7 @@
 #include "taxel.h"
 #include <urdf_tactile/tactile.h>
 #include <tactile_msgs/TactileContact.h>
+#include <Eigen/Dense>
 #include <map>
 #include <vector>
 
@@ -64,6 +65,8 @@ public:
 
 	template <typename Iterator>
 	void update(const TaxelMapping &mapping, Iterator begin, Iterator end);
+	bool all(std::vector<tactile_msgs::TactileContact> &contacts,
+	         const tactile_msgs::TactileContact &contact_template);
 	bool average(tactile_msgs::TactileContact &contact);
 
 private:
@@ -76,6 +79,9 @@ private:
 	std::vector<Taxel> taxels_;
 	/// mapping from channel name onto its TaxelMapping
 	SensorToTaxelMapping mappings_;
+	/// conversion from eigen pos, normal, amplitude to contact
+	void toContact(tactile_msgs::TactileContact &contact, const Eigen::Vector3d &pos,
+	               const Eigen::Vector3d &normal, const float &force_amplitude, const int i=-1);
 };
 
 } // namespace tactile

--- a/tactile_merger/src/merger.cpp
+++ b/tactile_merger/src/merger.cpp
@@ -96,7 +96,7 @@ template void Merger::update<std::vector<float>::const_iterator>
 (const ros::Time &stamp, const std::string &sensor_name,
 std::vector<float>::const_iterator begin, std::vector<float>::const_iterator end);
 
-tactile_msgs::TactileContacts Merger::getContacts() {
+tactile_msgs::TactileContacts Merger::getAllContacts() {
 	static ros::Duration timeout(1);
 	ros::Time now = ros::Time::now();
 
@@ -111,8 +111,34 @@ tactile_msgs::TactileContacts Merger::getContacts() {
 		contact.name = it->first; // group name
 		contact.header.frame_id = data->group->frame();
 		contact.header.stamp = data->timestamp;
+		// insert all contacts of the group into result array
+		data->group->all(contacts.contacts, contact);
+	}
+	return contacts;
+}
+
+tactile_msgs::TactileContacts Merger::getAverageContacts() {
+	static ros::Duration timeout(1);
+	ros::Time now = ros::Time::now();
+
+	tactile_msgs::TactileContacts contacts;
+	for (auto it = groups_.begin(), end = groups_.end(); it != end; ++it) {
+		const GroupDataPtr &data = it->second;
+		boost::unique_lock<boost::mutex> lock(data->mutex);
+		if (data->timestamp + timeout < now)
+    {
+      ROS_DEBUG_STREAM_NAMED("timeouts", "getAverageContacts timed out " << data->timestamp + timeout << " < " << now);
+			continue; // ignore stalled groups
+    }
+		tactile_msgs::TactileContact contact;
+		contact.name = it->first; // group name
+		contact.header.frame_id = data->group->frame();
+		contact.header.stamp = data->timestamp;
 		if (!data->group->average(contact))
+    {
+       ROS_DEBUG_STREAM_NAMED("contacts", "getAverageContacts no contact for group of frame_id " << contact.header.frame_id);
 			continue; // ignore not contacted groups
+    }
 
 		// insert all contacts of the group into result array
 		contacts.contacts.push_back(contact);

--- a/tactile_merger/src/merger.cpp
+++ b/tactile_merger/src/merger.cpp
@@ -126,19 +126,19 @@ tactile_msgs::TactileContacts Merger::getAverageContacts() {
 		const GroupDataPtr &data = it->second;
 		boost::unique_lock<boost::mutex> lock(data->mutex);
 		if (data->timestamp + timeout < now)
-    {
-      ROS_DEBUG_STREAM_NAMED("timeouts", "getAverageContacts timed out " << data->timestamp + timeout << " < " << now);
+		{
+			ROS_DEBUG_STREAM_NAMED("timeouts", "getAverageContacts timed out " << data->timestamp + timeout << " < " << now);
 			continue; // ignore stalled groups
-    }
+		}
 		tactile_msgs::TactileContact contact;
 		contact.name = it->first; // group name
 		contact.header.frame_id = data->group->frame();
 		contact.header.stamp = data->timestamp;
 		if (!data->group->average(contact))
-    {
-       ROS_DEBUG_STREAM_NAMED("contacts", "getAverageContacts no contact for group of frame_id " << contact.header.frame_id);
+		{
+			ROS_DEBUG_STREAM_NAMED("contacts", "getAverageContacts no contact for group of frame_id " << contact.header.frame_id);
 			continue; // ignore not contacted groups
-    }
+		}
 
 		// insert all contacts of the group into result array
 		contacts.contacts.push_back(contact);

--- a/tactile_merger/src/merger.cpp
+++ b/tactile_merger/src/merger.cpp
@@ -96,7 +96,7 @@ template void Merger::update<std::vector<float>::const_iterator>
 (const ros::Time &stamp, const std::string &sensor_name,
 std::vector<float>::const_iterator begin, std::vector<float>::const_iterator end);
 
-tactile_msgs::TactileContacts Merger::getAllContacts() {
+tactile_msgs::TactileContacts Merger::getAllTaxelContacts() {
 	static ros::Duration timeout(1);
 	ros::Time now = ros::Time::now();
 
@@ -117,7 +117,7 @@ tactile_msgs::TactileContacts Merger::getAllContacts() {
 	return contacts;
 }
 
-tactile_msgs::TactileContacts Merger::getAverageContacts() {
+tactile_msgs::TactileContacts Merger::getGroupContacts() {
 	static ros::Duration timeout(1);
 	ros::Time now = ros::Time::now();
 
@@ -127,7 +127,7 @@ tactile_msgs::TactileContacts Merger::getAverageContacts() {
 		boost::unique_lock<boost::mutex> lock(data->mutex);
 		if (data->timestamp + timeout < now)
 		{
-			ROS_DEBUG_STREAM_NAMED("timeouts", "getAverageContacts timed out " << data->timestamp + timeout << " < " << now);
+			ROS_DEBUG_STREAM_NAMED("timeouts", "getGroupContacts timed out " << data->timestamp + timeout << " < " << now);
 			continue; // ignore stalled groups
 		}
 		tactile_msgs::TactileContact contact;
@@ -136,7 +136,7 @@ tactile_msgs::TactileContacts Merger::getAverageContacts() {
 		contact.header.stamp = data->timestamp;
 		if (!data->group->average(contact))
 		{
-			ROS_DEBUG_STREAM_NAMED("contacts", "getAverageContacts no contact for group of frame_id " << contact.header.frame_id);
+			ROS_DEBUG_STREAM_NAMED("contacts", "getGroupContacts no contact for group of frame_id " << contact.header.frame_id);
 			continue; // ignore not contacted groups
 		}
 

--- a/tactile_merger/src/merger.cpp
+++ b/tactile_merger/src/merger.cpp
@@ -117,7 +117,7 @@ tactile_msgs::TactileContacts Merger::getAllTaxelContacts() {
 	return contacts;
 }
 
-tactile_msgs::TactileContacts Merger::getGroupContacts() {
+tactile_msgs::TactileContacts Merger::getGroupAveragedContacts() {
 	static ros::Duration timeout(1);
 	ros::Time now = ros::Time::now();
 
@@ -127,7 +127,7 @@ tactile_msgs::TactileContacts Merger::getGroupContacts() {
 		boost::unique_lock<boost::mutex> lock(data->mutex);
 		if (data->timestamp + timeout < now)
 		{
-			ROS_DEBUG_STREAM_NAMED("timeouts", "getGroupContacts timed out " << data->timestamp + timeout << " < " << now);
+			ROS_DEBUG_STREAM_NAMED("timeouts", "getGroupAveragedContacts timed out " << data->timestamp + timeout << " < " << now);
 			continue; // ignore stalled groups
 		}
 		tactile_msgs::TactileContact contact;
@@ -136,7 +136,7 @@ tactile_msgs::TactileContacts Merger::getGroupContacts() {
 		contact.header.stamp = data->timestamp;
 		if (!data->group->average(contact))
 		{
-			ROS_DEBUG_STREAM_NAMED("contacts", "getGroupContacts no contact for group of frame_id " << contact.header.frame_id);
+			ROS_DEBUG_STREAM_NAMED("contacts", "getGroupAveragedContacts no contact for group of frame_id " << contact.header.frame_id);
 			continue; // ignore not contacted groups
 		}
 

--- a/tactile_merger/src/merger_node.cpp
+++ b/tactile_merger/src/merger_node.cpp
@@ -60,9 +60,9 @@ int main(int argc, char *argv[])
 	{
 		ros::spinOnce();
 		if (no_clustering)
-			pub.publish(merger.getAllContacts());
+			pub.publish(merger.getAllTaxelContacts());
 		else
-			pub.publish(merger.getAverageContacts());
+			pub.publish(merger.getGroupContacts());
 		rate.sleep();
 	}
 

--- a/tactile_merger/src/merger_node.cpp
+++ b/tactile_merger/src/merger_node.cpp
@@ -62,7 +62,7 @@ int main(int argc, char *argv[])
 		if (no_clustering)
 			pub.publish(merger.getAllTaxelContacts());
 		else
-			pub.publish(merger.getGroupContacts());
+			pub.publish(merger.getGroupAveragedContacts());
 		rate.sleep();
 	}
 

--- a/tactile_merger/src/merger_node.cpp
+++ b/tactile_merger/src/merger_node.cpp
@@ -55,10 +55,14 @@ int main(int argc, char *argv[])
 	ros::Subscriber sub = nh.subscribe("tactile_states", 1, callback);
 
 	ros::Rate rate(nh_priv.param("rate", 100.));
+	bool no_clustering = nh_priv.param("no_clustering", false);
 	while (ros::ok())
 	{
 		ros::spinOnce();
-		pub.publish(merger.getContacts());
+		if (no_clustering)
+			pub.publish(merger.getAllContacts());
+		else
+			pub.publish(merger.getAverageContacts());
 		rate.sleep();
 	}
 

--- a/tactile_merger/src/taxel_group.cpp
+++ b/tactile_merger/src/taxel_group.cpp
@@ -124,7 +124,7 @@ bool TaxelGroup::all(std::vector<tactile_msgs::TactileContact> &contacts, const 
 	unsigned int i=0;
 	for (auto it = taxels_.begin(), end = taxels_.end(); it != end; ++it, ++i) {
 		tactile_msgs::TactileContact contact = contact_template;  // copy header and name
-		contact.name.append('_');
+		contact.name.append("_");
 		contact.name.append(std::to_string(i));
 
 		toContact(contact, it->position, it->normal, it->weight);  // add index

--- a/tactile_merger/src/taxel_group.cpp
+++ b/tactile_merger/src/taxel_group.cpp
@@ -97,8 +97,8 @@ template void TaxelGroup::update<std::vector<float>::const_iterator>
 std::vector<float>::const_iterator begin, std::vector<float>::const_iterator end);
 
 void TaxelGroup::toContact(tactile_msgs::TactileContact &contact, const Eigen::Vector3d &pos,
-                                                   const Eigen::Vector3d &normal, const float &force_amplitude,
-                                                   const int id)
+                           const Eigen::Vector3d &normal, const float &force_amplitude,
+                           const int id)
 {
 	// append the id if needed
 	if (id >= 0)

--- a/tactile_merger/src/taxel_group.cpp
+++ b/tactile_merger/src/taxel_group.cpp
@@ -97,17 +97,8 @@ template void TaxelGroup::update<std::vector<float>::const_iterator>
 std::vector<float>::const_iterator begin, std::vector<float>::const_iterator end);
 
 void TaxelGroup::toContact(tactile_msgs::TactileContact &contact, const Eigen::Vector3d &pos,
-                           const Eigen::Vector3d &normal, const float &force_amplitude,
-                           const int id)
+                           const Eigen::Vector3d &normal, const double force_amplitude)
 {
-	// append the id if needed
-	if (id >= 0)
-	{
-		std::stringstream sstr;
-		sstr << contact.name << "_" << id;
-		contact.name =  sstr.str();
-	}
-
 	Eigen::Vector3d force, torque;
 	contact.position.x = pos.x();
 	contact.position.y = pos.y();
@@ -131,9 +122,12 @@ void TaxelGroup::toContact(tactile_msgs::TactileContact &contact, const Eigen::V
 bool TaxelGroup::all(std::vector<tactile_msgs::TactileContact> &contacts, const tactile_msgs::TactileContact &contact_template)
 {
 	unsigned int i=0;
-	for (auto it = taxels_.begin(), end = taxels_.end(); it != end; ++it) {
+	for (auto it = taxels_.begin(), end = taxels_.end(); it != end; ++it, ++i) {
 		tactile_msgs::TactileContact contact = contact_template;  // copy header and name
-		toContact(contact, it->position, it->normal, it->weight, i++);  // add index
+		contact.name.append('_');
+		contact.name.append(std::to_string(i));
+
+		toContact(contact, it->position, it->normal, it->weight);  // add index
 		contacts.push_back(contact);
 	}
 	return true;


### PR DESCRIPTION
As discussed in #3 , in order to produce tactile PCLs easily for each taxels, a non-clustering option was added to the tactile_merger