### PR TITLE
Tactile pcl threshold

### DIFF
--- a/tactile_pcl/src/pcl_collector.cpp
+++ b/tactile_pcl/src/pcl_collector.cpp
@@ -11,7 +11,7 @@ namespace tactile {
 
 ros::Duration PCLCollector::timeout_;
 
-PCLCollector::PCLCollector(const std::string &target_frame, const float &threshold)
+PCLCollector::PCLCollector(const std::string &target_frame, const double threshold)
    : tf_buffer_()
    , tf_listener_(tf_buffer_)
    , threshold_(threshold)

--- a/tactile_pcl/src/pcl_collector.h
+++ b/tactile_pcl/src/pcl_collector.h
@@ -24,7 +24,7 @@ class PCLCollector : public boost::mutex
 public:
 	typedef pcl::PointXYZINormal ContactPoint;
 
-	PCLCollector(const std::string &target_frame="");
+	PCLCollector(const std::string &target_frame="", const float &threshold=0.0);
 	void initFromRobotDescription(const std::string &param="robot_description");
 
 	template <typename M, typename F>
@@ -60,6 +60,7 @@ protected:
 	boost::shared_ptr<tf2_ros::MessageFilterBase> tf_filter_;
 
 	static ros::Duration timeout_;
+	float threshold_;
 };
 
 } // namespace tactile

--- a/tactile_pcl/src/pcl_collector.h
+++ b/tactile_pcl/src/pcl_collector.h
@@ -24,7 +24,7 @@ class PCLCollector : public boost::mutex
 public:
 	typedef pcl::PointXYZINormal ContactPoint;
 
-	PCLCollector(const std::string &target_frame="", const float &threshold=0.0);
+	PCLCollector(const std::string &target_frame="", const double threshold=0.0);
 	void initFromRobotDescription(const std::string &param="robot_description");
 
 	template <typename M, typename F>
@@ -60,7 +60,7 @@ protected:
 	boost::shared_ptr<tf2_ros::MessageFilterBase> tf_filter_;
 
 	static ros::Duration timeout_;
-	float threshold_;
+	double threshold_;
 };
 
 } // namespace tactile

--- a/tactile_pcl/src/tactile_pcl_node.cpp
+++ b/tactile_pcl/src/tactile_pcl_node.cpp
@@ -31,7 +31,8 @@ int main(int argc, char **argv) {
 	ros::NodeHandle nh_priv("~");
 
 	ros::Publisher pub = nh.advertise<sensor_msgs::PointCloud2>("tactile_pcl", 10);
-	PCLCollector collector(nh_priv.param<std::string>("frame", ""));
+	float threshold = nh_priv.param<float>("threshold", 0.0);
+	PCLCollector collector(nh_priv.param<std::string>("frame", ""), threshold);
 	ros::Rate rate(nh_priv.param("rate", 100.));
 
 	switch (1) {

--- a/tactile_pcl/src/tactile_pcl_node.cpp
+++ b/tactile_pcl/src/tactile_pcl_node.cpp
@@ -18,9 +18,12 @@ void run(ros::Publisher &pub, PCLCollector &collector, ros::Rate &rate) {
 			msg.header.frame_id = collector.targetFrame();
 			collector.clear();
 		}
-		msg.header.stamp = ros::Time::now();
-		msg.header.seq++;
-		pub.publish(msg);
+		if (msg.data.size())
+		{
+			msg.header.stamp = ros::Time::now();
+			msg.header.seq++;
+			pub.publish(msg);
+		}
 		rate.sleep();
 	}
 }

--- a/tactile_pcl/src/tactile_pcl_node.cpp
+++ b/tactile_pcl/src/tactile_pcl_node.cpp
@@ -34,8 +34,7 @@ int main(int argc, char **argv) {
 	ros::NodeHandle nh_priv("~");
 
 	ros::Publisher pub = nh.advertise<sensor_msgs::PointCloud2>("tactile_pcl", 10);
-	float threshold = nh_priv.param<float>("threshold", 0.0);
-	PCLCollector collector(nh_priv.param<std::string>("frame", ""), threshold);
+	PCLCollector collector(nh_priv.param<std::string>("frame", ""), nh_priv.param<double>("threshold", 0.0));
 	ros::Rate rate(nh_priv.param("rate", 100.));
 
 	switch (1) {

--- a/tactile_pcl/src/tactile_pcl_node.cpp
+++ b/tactile_pcl/src/tactile_pcl_node.cpp
@@ -9,6 +9,7 @@ using namespace tactile;
 
 void run(ros::Publisher &pub, PCLCollector &collector, ros::Rate &rate) {
 	sensor_msgs::PointCloud2 msg;
+	bool send_empty = false;  // should we send an empty message?
 	while (ros::ok())
 	{
 		ros::spinOnce();
@@ -18,8 +19,9 @@ void run(ros::Publisher &pub, PCLCollector &collector, ros::Rate &rate) {
 			msg.header.frame_id = collector.targetFrame();
 			collector.clear();
 		}
-		if (msg.data.size())
+		if (!msg.data.empty() || send_empty)
 		{
+			send_empty = !msg.data.empty();  // only send a single empty message in a row
 			msg.header.stamp = ros::Time::now();
 			msg.header.seq++;
 			pub.publish(msg);


### PR DESCRIPTION
To avoid useless data being produced like empty data or PCLs stemming from contact noise, this PR adds the possibility to define a threshold under which the contact_state value is not considered for PCL generation