### PR TITLE
Improve failure reporting

### DIFF
--- a/rviz_tactile_plugins/src/tactile_contact_display.cpp
+++ b/rviz_tactile_plugins/src/tactile_contact_display.cpp
@@ -177,7 +177,14 @@ void TactileContactDisplay::onInitialize()
 
 void TactileContactDisplay::reset()
 {
-  Display::reset();
+  // amongst others, this method is called when time was reset
+  ros::Time now = ros::Time::now();
+  if(now < last_update_) {
+    ROS_WARN_STREAM("Detected jump back in time of " << (last_update_ - now).toSec() << "s. Clearing contacts.");
+    contacts_.clear();
+  } else
+    // If time was reset, don't clear display statuses via Display::reset()
+    Display::reset();
 }
 
 void TactileContactDisplay::onEnable()
@@ -250,10 +257,6 @@ void TactileContactDisplay::update(float wall_dt, float ros_dt)
   ros::Duration timeout(timeout_property_->getFloat());
   boost::unique_lock<boost::mutex> lock(mutex_);
 
-  if(now < last_update_) {
-    ROS_WARN_STREAM("Detected jump back in time of " << (last_update_ - now).toSec() << "s. Clearing contacts.");
-    contacts_.clear();
-  }
   last_update_ = now;
   if (!last_msg_.isZero() && last_msg_ + timeout < now)
     setStatus(StatusProperty::Warn, "Topic", "No recent msg");

--- a/rviz_tactile_plugins/src/tactile_contact_display.h
+++ b/rviz_tactile_plugins/src/tactile_contact_display.h
@@ -103,7 +103,8 @@ private:
   ros::Subscriber  sub_;
   std::map<std::string, std::pair<tactile_msgs::TactileContact, WrenchVisualPtr> > contacts_;
   boost::mutex mutex_;
-  ros::Time last_update_;
+  ros::Time last_update_;  // last seen ROS timestamp
+  ros::Time last_msg_;     // timestamp when last received a message
 };
 
 } // namespace tactile

--- a/rviz_tactile_plugins/src/tactile_state_display.cpp
+++ b/rviz_tactile_plugins/src/tactile_state_display.cpp
@@ -60,7 +60,7 @@ TactileStateDisplay::TactileStateDisplay()
   : mode_(::tactile::TactileValue::rawCurrent)
 {
   topic_property_ = new rviz::RosTopicProperty
-      ("topic", "/tactile_state", "tactile_msgs/TactileState", "",
+      ("Topic", "/tactile_states", "tactile_msgs/TactileState", "",
        this, SLOT(onTopicChanged()));
 
   robot_description_property_ = new rviz::StringProperty
@@ -251,9 +251,9 @@ void TactileStateDisplay::onRobotDescriptionChanged()
       }
     }
     if (sensors_.size())
-      setStatus(rviz::StatusProperty::Ok, ROBOT_DESC, QString("found %1 tactile sensors").arg(sensors_.size()));
+      setStatus(rviz::StatusProperty::Ok, ROBOT_DESC, QString("Found %1 tactile sensors").arg(sensors_.size()));
     else
-      setStatus(rviz::StatusProperty::Warn, ROBOT_DESC, "no tactile sensors found");
+      setStatus(rviz::StatusProperty::Warn, ROBOT_DESC, "No tactile sensors found");
   } catch (const std::exception &e) {
     setStatus(rviz::StatusProperty::Error, ROBOT_DESC, e.what());
   }

--- a/rviz_tactile_plugins/src/tactile_state_display.cpp
+++ b/rviz_tactile_plugins/src/tactile_state_display.cpp
@@ -154,7 +154,15 @@ void TactileStateDisplay::onInitialize()
 
 void TactileStateDisplay::reset()
 {
-  Display::reset();
+  // amongst others, this method is called when time was reset
+  ros::Time now = ros::Time::now();
+  if(now < last_update_) {
+    ROS_WARN_STREAM("Detected jump back in time of " << (last_update_ - now).toSec() << "s. Clearing taxels.");
+    for (auto& sensor : sensors_)
+      sensor.second->resetTime();  // expire the sensor data
+  } else
+    // If time was reset, don't clear display statuses via Display::reset()
+    Display::reset();
 }
 
 void TactileStateDisplay::resetTactile()
@@ -345,11 +353,6 @@ void TactileStateDisplay::update(float wall_dt, float ros_dt)
 
   ros::Time now = ros::Time::now();
   ros::Duration timeout(timeout_property_->getFloat());
-  if(now < last_update_) {
-    ROS_WARN_STREAM("Detected jump back in time of " << (last_update_ - now).toSec() << "s. Clearing taxels.");
-    for (auto& sensor : sensors_)
-      sensor.second->resetTime();  // expire the sensor data
-  }
   last_update_ = now;
   if (!last_msg_.isZero() && last_msg_ + timeout < now)
     setStatus(StatusProperty::Warn, "Topic", "No recent msg");

--- a/rviz_tactile_plugins/src/tactile_state_display.cpp
+++ b/rviz_tactile_plugins/src/tactile_state_display.cpp
@@ -321,8 +321,12 @@ void TactileStateDisplay::onAllVisibleChanged()
 // This is our callback to handle an incoming message.
 void TactileStateDisplay::processMessage(const tactile_msgs::TactileState::ConstPtr& msg)
 {
-  setStatus(StatusProperty::Ok, "Topic", "Ok");
   last_msg_ = ros::Time::now();
+  if (msg->header.stamp + ros::Duration(timeout_property_->getFloat()) < last_msg_)
+    setStatus(StatusProperty::Error, "Topic", "Received an outdated msg");
+  else
+    setStatus(StatusProperty::Ok, "Topic", "Ok");
+
   for (auto sensor = msg->sensors.begin(), end = msg->sensors.end(); sensor != end; ++sensor)
   {
     const std::string &channel = sensor->name;

--- a/rviz_tactile_plugins/src/tactile_state_display.cpp
+++ b/rviz_tactile_plugins/src/tactile_state_display.cpp
@@ -328,7 +328,7 @@ void TactileStateDisplay::processMessage(const tactile_msgs::TactileState::Const
     const std::string &channel = sensor->name;
     auto range = sensors_.equal_range(channel);
     for (auto s = range.first, range_end = range.second; s != range_end; ++s) {
-      s->second->update(last_msg_, sensor->values);
+      s->second->update(msg->header.stamp, sensor->values);
     }
   }
 }

--- a/rviz_tactile_plugins/src/tactile_state_display.h
+++ b/rviz_tactile_plugins/src/tactile_state_display.h
@@ -102,7 +102,8 @@ private:
   ros::Subscriber  sub_;
   /// list of all sensors, accessible by sensor name
   std::multimap<std::string, TactileVisualBase*> sensors_;
-  ros::Time last_update_;
+  ros::Time last_update_;  // last seen ROS timestamp
+  ros::Time last_msg_;     // timestamp when last received a message
 
   ::tactile::TactileValue::Mode mode_;
   ColorMap abs_color_map_;

--- a/rviz_tactile_plugins/src/tactile_visual_base.cpp
+++ b/rviz_tactile_plugins/src/tactile_visual_base.cpp
@@ -141,10 +141,10 @@ bool TactileVisualBase::updatePose()
   {
     std::string error;
 	 context_->getFrameManager()->transformHasProblems(frame, ros::Time(), error);
-    owner_->setStatusStd(rviz::StatusProperty::Error, getNameStd(), error);
+    owner_->setStatus(rviz::StatusProperty::Error, getName(), error.c_str());
     return false;
   }
-  owner_->setStatus(rviz::StatusProperty::Ok, getName(), "");
+  owner_->deleteStatus(getName());
   scene_node_->setPosition(pos);
   scene_node_->setOrientation(quat);
   return true;


### PR DESCRIPTION
Resolves #16. 
I only partially handled your new request for a warning/error about an received, but outdated message.
It's implemented for TactileStateDisplay, but not for TactileContactDisplay. The latter would require this check for each and every contact received (within a message), which is somewhat costly.
You also note this issue "automatically", by not seeing wrenches displayed anymore, but no warning "no recent msg" popping up.

<details>
<summary>I tested this thoroughly with the enclosed `tactile_states` generator script:</summary>

```python
#!/usr/bin/env python

from tactile_msgs.msg import TactileState
from sensor_msgs.msg import ChannelFloat32
from rosgraph_msgs.msg import Clock
from time import sleep
import rospy
import numpy

rospy.init_node('send_tactile_states')
pub = rospy.Publisher('tactile_states', TactileState, queue_size=1)

sim_time = rospy.get_param('use_sim_time', False)
clock_pub = rospy.Publisher('clock', Clock, queue_size=1)
clock_msg = Clock()

rate = rospy.Rate(10)
t = 0
period = 5

msg = TactileState()
msg.sensors.append(ChannelFloat32())
msg.sensors[0].name = rospy.get_param('~channel', 'tactile')
values = numpy.linspace(0, numpy.pi, num=rospy.get_param('~taxels', 64))
while not rospy.is_shutdown():
    stamp = rospy.Time.from_sec(t) if sim_time else rospy.Time.now()
    clock_msg.clock = stamp
    clock_pub.publish(clock_msg)
    print(stamp.secs)

    msg.header.stamp = stamp
    msg.sensors[0].values = 0.6 + 0.4 * numpy.sin(values + 2.*numpy.pi/period*t)
    pub.publish(msg)

    t += rate.sleep_dur.to_sec()
    sleep(rate.sleep_dur.to_sec())
```
</details>
