### PR TITLE
Export includes to allow other plugins to instantiate tactile displays

### DIFF
--- a/rviz_tactile_plugins/CMakeLists.txt
+++ b/rviz_tactile_plugins/CMakeLists.txt
@@ -29,7 +29,7 @@ find_package(tactile_filters REQUIRED)
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-#  INCLUDE_DIRS include
+INCLUDE_DIRS src
 #  LIBRARIES agni_tf_tools
 CATKIN_DEPENDS rviz tactile_msgs roscpp
 #  DEPENDS system_lib

--- a/urdf_tactile/package.xml
+++ b/urdf_tactile/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>urdf</depend>
+  <depend>urdfdom</depend>
   <depend>pluginlib</depend>
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
This PR permits external plugins to re-use classes or plugin displays of `rviz_tactile_plugins`

Similar exports are done in the main [rviz https://github.com/ros-visualization/rviz/blob/noetic-devel/CMakeLists.txt#L184](https://github.com/ros-visualization/rviz/blob/6a234b4404c5ee71051f0b338ab8d5d2d931c27b/CMakeLists.txt#L184)