### PR TITLE
Use (link, name) pair as map key

### DIFF
--- a/rviz_tactile_plugins/src/tactile_contact_display.cpp
+++ b/rviz_tactile_plugins/src/tactile_contact_display.cpp
@@ -40,6 +40,7 @@
 #include <QApplication>
 #include <QTimer>
 #include <boost/thread/locks.hpp>
+#include <functional>
 
 namespace rviz {
 namespace tactile {
@@ -203,13 +204,13 @@ void TactileContactDisplay::triggerFullUpdate()
 
 void TactileContactDisplay::processMessage(const tactile_msgs::TactileContact &msg)
 {
-	std::string id = msg.header.frame_id + msg.name;
+	const auto &id = std::make_pair(msg.header.frame_id, msg.name);
 	auto it = contacts_.find(id);
 	if (it != contacts_.end()) {
 		tactile_msgs::TactileContact &m = it->second.first;
 		m = msg;
 	} else {
-		contacts_.insert(std::make_pair(id, std::make_pair(msg, WrenchVisualPtr())));
+		contacts_.insert(std::make_pair(std::cref(id), std::make_pair(msg, WrenchVisualPtr())));
 	}
 }
 

--- a/rviz_tactile_plugins/src/tactile_contact_display.h
+++ b/rviz_tactile_plugins/src/tactile_contact_display.h
@@ -97,7 +97,7 @@ private:
 
 	ros::NodeHandle nh_;
 	ros::Subscriber sub_;
-	std::map<std::string, std::pair<tactile_msgs::TactileContact, WrenchVisualPtr> > contacts_;
+	std::map<std::pair<std::string, std::string>, std::pair<tactile_msgs::TactileContact, WrenchVisualPtr> > contacts_;
 	boost::mutex mutex_;
 	ros::Time last_update_;  // last seen ROS timestamp
 	ros::Time last_msg_;  // timestamp when last received a message


### PR DESCRIPTION
Although this requires a copy operation for map::find(key) as well, it is much faster due to small string optimization.