### PR TITLE
Fix segfault of tactile_pcl_node

### DIFF
--- a/tactile_pcl/src/contact_forwarder.h
+++ b/tactile_pcl/src/contact_forwarder.h
@@ -12,6 +12,7 @@ public:
 	{
 		connectInput(f);
 	}
+	~ContactForwarder() { incoming_connection_.disconnect(); }
 
 	template <class F>
 	void connectInput(F& f)

--- a/tactile_pcl/src/pcl_collector.cpp
+++ b/tactile_pcl/src/pcl_collector.cpp
@@ -11,13 +11,6 @@ namespace tactile {
 
 ros::Duration PCLCollector::timeout_;
 
-PCLCollector::PCLCollector(const std::string &target_frame, const double threshold)
-  : tf_buffer_(), tf_listener_(tf_buffer_), threshold_(threshold)
-{
-	initFromRobotDescription();
-	setTargetFrame(target_frame);
-}
-
 static void loadRobotDescription(std::string &xml_string, const std::string &param)
 {
 	ros::NodeHandle nh;

--- a/tactile_pcl/src/tactile_pcl_node.cpp
+++ b/tactile_pcl/src/tactile_pcl_node.cpp
@@ -36,24 +36,25 @@ int main(int argc, char **argv)
 	ros::NodeHandle nh_priv("~");
 
 	ros::Publisher pub = nh.advertise<sensor_msgs::PointCloud2>("tactile_pcl", 10);
-	PCLCollector collector(nh_priv.param<std::string>("frame", ""), nh_priv.param<double>("threshold", 0.0));
 	ros::Rate rate(nh_priv.param("rate", 100.));
+	double threshold = nh_priv.param<double>("threshold", 0.0);
+	auto frame = nh_priv.param<std::string>("frame", "");
 
 	switch (1) {
 		case 0: {
 			message_filters::Subscriber<tactile_msgs::TactileContact> sub(nh, "tactile_contact_state", 100);
-			collector.setSource<tactile_msgs::TactileContact>(sub, 10);
+			PCLCollector collector(sub, 10, frame, threshold);
 			run(pub, collector, rate);
 		} break;
 		case 1: {
 			message_filters::Subscriber<tactile_msgs::TactileContacts> sub(nh, "tactile_contact_states", 10);
 			ContactForwarder forwarder(sub);
-			collector.setSource<tactile_msgs::TactileContact>(forwarder, 100);
+			PCLCollector collector(forwarder, 100, frame, threshold);
 			run(pub, collector, rate);
 		} break;
 		case 2: {
 			//		message_filters::Subscriber<tactile_msgs::TactileState> sub(nh, "tactile_states", 10);
-			//		collector.setSource(sub);
+			//		PCLCollector collector(sub, 10, frame, threshold);
 			//		run(pub, collector, rate);
 		} break;
 	}


### PR DESCRIPTION
- A `MessageFilter` chain needs to get destroyed in exactly reverse order compared to construction.
- `ContactForwarder`: disconnect connection on destruction
- Migrate `boost::shared_ptr` -> `std::shared_ptr`

Fixes #33