### PR TITLE
Fix enabling of sensors in TactileStateDisplay

### DIFF
--- a/rviz_tactile_plugins/src/tactile_state_display.cpp
+++ b/rviz_tactile_plugins/src/tactile_state_display.cpp
@@ -355,12 +355,10 @@ void TactileStateDisplay::update(float wall_dt, float ros_dt)
 	for (auto &it : sensors_) {
 		TactileVisualBase &sensor = *it.second;
 		sensor.updateRangeProperty();
-		if (!sensor.isVisible())
-			continue;
 
 		bool enabled = !sensor.expired(now, timeout) && sensor.updatePose();
 		sensor.setEnabled(enabled);
-		if (!enabled)
+		if (!enabled || !sensor.isVisible())
 			continue;
 
 		sensor.updateVisual();

--- a/rviz_tactile_plugins/src/tactile_visual_base.cpp
+++ b/rviz_tactile_plugins/src/tactile_visual_base.cpp
@@ -217,6 +217,8 @@ void TactileVisualBase::setVisible(bool visible)
 
 void TactileVisualBase::setEnabled(bool enabled)
 {
+	if (enabled == enabled_)
+		return;
 	enabled_ = enabled;
 	onVisibleChanged();
 }


### PR DESCRIPTION
Given a TactileStateDisplay with a few sensors switched off.
Saving and reloading this config, results in those sensors not only being switched off, but also being disabled.
Thus, they couldn't get switched on easily.
