### PR TITLE
Change licenses

### DIFF
--- a/tactile_msgs/package.xml
+++ b/tactile_msgs/package.xml
@@ -4,7 +4,7 @@
   <version>0.1.0</version>
   <description>Tactile messages and contact messages</description>
 
-  <maintainer email="gwalck@techfak.uni-bielefeld.de">Guillaume Walck</maintainer>
+  <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
 
   <license>LGPLv3</license>
 

--- a/tactile_msgs/package.xml
+++ b/tactile_msgs/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="gwalck@techfak.uni-bielefeld.de">Guillaume Walck</maintainer>
 
-  <license>GPLv3</license>
+  <license>LGPLv3</license>
 
   <author email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</author>
   <author email="gwalck@techfak.uni-bielefeld.de">Guillaume Walck</author>

--- a/tactile_pcl/package.xml
+++ b/tactile_pcl/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="troehlig@techfak.uni-bielefeld.de">Tobias Roehlig</maintainer>
 
-  <license>GPLv3</license>
+  <license>LGPLv3</license>
 
   <author email="troehlig@techfak.uni-bielefeld.de">Tobias Roehlig</author>
   <author email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</author>

--- a/tactile_pcl/package.xml
+++ b/tactile_pcl/package.xml
@@ -4,13 +4,12 @@
   <version>0.1.0</version>
   <description>Convert TactileState or TactileContact messages into pcl messages</description>
 
-  <maintainer email="troehlig@techfak.uni-bielefeld.de">Tobias Roehlig</maintainer>
+  <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
 
   <license>LGPLv3</license>
 
   <author email="troehlig@techfak.uni-bielefeld.de">Tobias Roehlig</author>
   <author email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</author>
-  <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>sensor_msgs</depend>

--- a/tactile_state_publisher/package.xml
+++ b/tactile_state_publisher/package.xml
@@ -6,7 +6,7 @@
                offers concatenating several messages from a source of tactile_states
                and provides a tactile_bias node</description>
 
-  <maintainer email="gwalck@techfak.uni-bielefeld.de">Guillaume Walck</maintainer>
+  <maintainer email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</maintainer>
 
   <author email="gwalck@techfak.uni-bielefeld.de">Guillaume Walck</author>
   <author email="rhaschke@techfak.uni-bielefeld.de">Robert Haschke</author>


### PR DESCRIPTION
As discussed internally and agreed please accept this PR to change the licenses of `tactile_msgs` and, if you manage to get approval from Tobias Roehlig also of `tactile_pcl`.

I additionally changed package maintainers for packages I won't maintain, keeping only `tactile_state_calibrator` and `tactile_calibration_tools` for now (I should work on those in the coming months, but maybe only at our side)