### PR TITLE
Added support for tf_prefix

### DIFF
--- a/tactile_merger/include/tactile_merger/merger.h
+++ b/tactile_merger/include/tactile_merger/merger.h
@@ -38,6 +38,7 @@ class Merger
 {
 public:
 	Merger();
+	explicit Merger(const std::string &tf_prefix = "");
 	~Merger();
 
 	void init(const std::string &param = "robot_description");
@@ -50,6 +51,7 @@ public:
 	tactile_msgs::TactileContacts getAllTaxelContacts();
 
 private:
+	std::string tf_prefix_;
 	struct GroupData;
 	typedef boost::shared_ptr<GroupData> GroupDataPtr;
 

--- a/tactile_merger/src/merger.cpp
+++ b/tactile_merger/src/merger.cpp
@@ -46,7 +46,17 @@ struct Merger::GroupData
 
 Merger::GroupData::GroupData(const TaxelGroupPtr &group) : group(group) {}
 
-Merger::Merger() {}
+Merger::Merger(const std::string &tf_prefix) : tf_prefix_(tf_prefix)
+{
+	// prepare tf_prefix for easy future concatenation
+	if (!tf_prefix_.empty()) {
+		if (tf_prefix_[0] == '/')
+			tf_prefix_.erase(0, 1);  // strip front slash if any
+		if (!tf_prefix_.empty() && tf_prefix_.back() != '/')
+			tf_prefix_.push_back('/');  // if still non-empty and not trailing slash, add it
+	}
+}
+
 Merger::~Merger()
 {
 	sensors_.clear();
@@ -117,7 +127,7 @@ tactile_msgs::TactileContacts Merger::getAllTaxelContacts()
 
 		tactile_msgs::TactileContact contact;
 		contact.name = name_data.first;  // group name
-		contact.header.frame_id = data->group->frame();
+		contact.header.frame_id = tf_prefix_ + data->group->frame();
 		contact.header.stamp = data->timestamp;
 		// insert all contacts of the group into result array
 		data->group->all(contacts.contacts, contact);
@@ -141,7 +151,7 @@ tactile_msgs::TactileContacts Merger::getGroupAveragedContacts()
 		}
 		tactile_msgs::TactileContact contact;
 		contact.name = name_data.first;  // group name
-		contact.header.frame_id = data->group->frame();
+		contact.header.frame_id = tf_prefix_ + data->group->frame();
 		contact.header.stamp = data->timestamp;
 		if (!data->group->average(contact)) {
 			ROS_DEBUG_STREAM_NAMED("contacts", "getGroupAveragedContacts no contact for group of frame_id "

--- a/tactile_merger/src/merger_node.cpp
+++ b/tactile_merger/src/merger_node.cpp
@@ -48,7 +48,8 @@ int main(int argc, char *argv[])
 	ros::NodeHandle nh;
 	ros::NodeHandle nh_priv("~");
 
-	tactile::Merger merger;
+	std::string tf_prefix = nh_priv.param("tf_prefix", std::string());
+	tactile::Merger merger(tf_prefix);
 	merger.init();
 
 	ros::Publisher pub = nh.advertise<tactile_msgs::TactileContacts>("tactile_contact_states", 5);
@@ -60,6 +61,7 @@ int main(int argc, char *argv[])
 	ros::Time last_update;
 	ros::Rate rate(nh_priv.param("rate", 100.));
 	bool no_clustering = nh_priv.param("no_clustering", false);
+
 	while (ros::ok()) {
 		ros::spinOnce();
 		ros::Time now = ros::Time::now();


### PR DESCRIPTION
In case a producer of _TactileContacts_ has its transforms in a TF subtree due to a **tf_prefix** in (for instance when 2 hand models are loaded in a namespace with each a different `tf_prefix`  as in https://github.com/ubi-agni/human_hand/blob/master/launch/two_gloves.launch ), the **frame_id** of the _TactileContacts_ must also contain this **tf_prefix** to enable transforms to be resolved in `tactile_pcl` .
This PR adds the possibility to set a **tf_prefix** 