### PR TITLE
Migration to Tinyxml2 (required for urdfdom 4.x)

### DIFF
--- a/tactile_calibration/tactile_state_calibrator/CMakeLists.txt
+++ b/tactile_calibration/tactile_state_calibrator/CMakeLists.txt
@@ -3,9 +3,7 @@ project(tactile_state_calibrator)
 
 find_package(catkin REQUIRED COMPONENTS roscpp tactile_msgs)
 find_package(tactile_filters REQUIRED)
-
-find_package(PkgConfig REQUIRED)
-pkg_search_module(YAML REQUIRED yaml-cpp)
+find_package(yaml-cpp REQUIRED)
 
 catkin_package(
 #  INCLUDE_DIRS include
@@ -14,10 +12,10 @@ CATKIN_DEPENDS tactile_msgs roscpp
 #  DEPENDS
 )
 
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS} ${YAML_INCLUDE_DIRS})
+include_directories(SYSTEM ${catkin_INCLUDE_DIRS} ${YAML_CPP_INCLUDE_DIR})
 
 add_executable(${PROJECT_NAME} src/tactile_state_calibrator.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} tactile_filters ${YAML_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} tactile_filters ${YAML_CPP_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/tactile_calibration/tactile_state_calibrator/package.xml
+++ b/tactile_calibration/tactile_state_calibrator/package.xml
@@ -9,7 +9,7 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend>pkg-config</buildtool_depend>
+  <depend>yaml-cpp</depend>
   <depend>roscpp</depend>
   <depend>tactile_msgs</depend>
   <depend>tactile_filters</depend>

--- a/urdf_tactile/CMakeLists.txt
+++ b/urdf_tactile/CMakeLists.txt
@@ -7,7 +7,7 @@ project(urdf_tactile)
 find_package(Boost REQUIRED system)
 find_package(urdfdom REQUIRED)
 find_package(catkin REQUIRED COMPONENTS roscpp cmake_modules)
-find_package(TinyXML REQUIRED)
+find_package(TinyXML2 REQUIRED)
 
 ###################################
 ## catkin specific configuration ##
@@ -22,7 +22,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME} ${PROJECT_NAME}_tools
   CATKIN_DEPENDS roscpp
-  DEPENDS urdfdom Boost TinyXML
+  DEPENDS urdfdom Boost TinyXML2
 )
 
 include_directories(SYSTEM ${Boost_INCLUDE_DIR} ${urdfdom_INCLUDE_DIRS})

--- a/urdf_tactile/CMakeLists.txt
+++ b/urdf_tactile/CMakeLists.txt
@@ -25,7 +25,7 @@ catkin_package(
   DEPENDS urdfdom Boost TinyXML
 )
 
-include_directories(SYSTEM ${Boost_INCLUDE_DIR})
+include_directories(SYSTEM ${Boost_INCLUDE_DIR} ${urdfdom_INCLUDE_DIRS})
 include_directories(SYSTEM include ${catkin_INCLUDE_DIRS})
 file(GLOB_RECURSE PROJECT_INCLUDES *.h)
 

--- a/urdf_tactile/CMakeLists.txt
+++ b/urdf_tactile/CMakeLists.txt
@@ -5,7 +5,7 @@ project(urdf_tactile)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(Boost REQUIRED system)
-find_package(urdfdom REQUIRED)
+find_package(urdfdom 4 REQUIRED)
 find_package(catkin REQUIRED COMPONENTS roscpp cmake_modules)
 find_package(TinyXML2 REQUIRED)
 

--- a/urdf_tactile/include/urdf_tactile/parser.h
+++ b/urdf_tactile/include/urdf_tactile/parser.h
@@ -37,7 +37,7 @@
 #pragma once
 
 #include "sensor.h"
-#include <tinyxml.h>
+#include <tinyxml2.h>
 
 namespace urdf {
 namespace tactile {
@@ -45,10 +45,10 @@ namespace tactile {
 class TactileSensorParser
 {
 public:
-	TactileSensor *parse(TiXmlElement &sensor_element) const;
+	TactileSensor *parse(tinyxml2::XMLElement &sensor_element) const;
 };
 
-SensorMap parseSensors(TiXmlDocument &urdf_xml);
+SensorMap parseSensors(tinyxml2::XMLDocument &urdf_xml);
 SensorMap parseSensors(const std::string &xml);
 SensorMap parseSensorsFromParam(const std::string &param);
 SensorMap parseSensorsFromFile(const std::string &filename);

--- a/urdf_tactile/package.xml
+++ b/urdf_tactile/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
-  <depend>urdfdom</depend>
+  <depend version_gte="4">urdfdom</depend>
   <depend>roscpp</depend>
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/urdf_tactile/src/CMakeLists.txt
+++ b/urdf_tactile/src/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(${PROJECT_NAME} SHARED
 	utils.cpp
 	${PROJECT_INCLUDES}
 )
-target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${TinyXML_LIBRARIES} ${urdfdom_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} tinyxml2 ${urdfdom_LIBRARIES} ${catkin_LIBRARIES})
 
 add_library(${PROJECT_NAME}_tools SHARED
 	taxel_info_iterator.cpp

--- a/urdf_tactile/src/parser.cpp
+++ b/urdf_tactile/src/parser.cpp
@@ -77,7 +77,7 @@ tactile::Vector2<double> parseAttribute<tactile::Vector2<double> >(const char *v
 	return tactile::Vector2<double>(xy[0], xy[1]);
 }
 
-bool parseTactileTaxel(TactileTaxel &taxel, TiXmlElement *config)
+bool parseTactileTaxel(TactileTaxel &taxel, tinyxml2::XMLElement *config)
 {
 	taxel.clear();
 
@@ -101,7 +101,7 @@ bool parseTactileTaxel(TactileTaxel &taxel, TiXmlElement *config)
 	return true;
 }
 
-bool parseTactileArray(TactileArray &array, TiXmlElement *config)
+bool parseTactileArray(TactileArray &array, tinyxml2::XMLElement *config)
 {
 	array.clear();
 	try {
@@ -122,9 +122,9 @@ bool parseTactileArray(TactileArray &array, TiXmlElement *config)
 	return true;
 }
 
-TactileSensor *TactileSensorParser::parse(TiXmlElement &config) const
+TactileSensor *TactileSensorParser::parse(tinyxml2::XMLElement &config) const
 {
-	TiXmlElement *parent = config.Parent()->ToElement()->FirstChildElement("parent");
+	tinyxml2::XMLElement *parent = config.Parent()->ToElement()->FirstChildElement("parent");
 	if (!parent) {
 		CONSOLE_BRIDGE_logError("No <parent> tag given for the sensor.");
 		return nullptr;
@@ -134,7 +134,7 @@ TactileSensor *TactileSensorParser::parse(TiXmlElement &config) const
 	const std::string empty;
 	tactile->name_ = parseAttribute<std::string>(*config.Parent()->ToElement(), "name");
 	tactile->parent_link_ = parseAttribute<std::string>(*parent, "link");
-	if (TiXmlElement *o = config.Parent()->ToElement()->FirstChildElement("origin")) {
+	if (tinyxml2::XMLElement *o = config.Parent()->ToElement()->FirstChildElement("origin")) {
 		if (!parsePose(tactile->origin_, o))
 			return nullptr;
 	}
@@ -143,7 +143,7 @@ TactileSensor *TactileSensorParser::parse(TiXmlElement &config) const
 	tactile->group_ = parseAttribute<std::string>(*config.Parent()->ToElement(), "group", &empty);
 
 	// multiple Taxels (optional)
-	for (TiXmlElement *taxel_xml = config.FirstChildElement("taxel"); taxel_xml;
+	for (tinyxml2::XMLElement *taxel_xml = config.FirstChildElement("taxel"); taxel_xml;
 	     taxel_xml = taxel_xml->NextSiblingElement("taxel")) {
 		TactileTaxelSharedPtr taxel;
 		taxel.reset(new TactileTaxel());
@@ -156,7 +156,7 @@ TactileSensor *TactileSensorParser::parse(TiXmlElement &config) const
 	}
 
 	// a single array (optional)
-	for (TiXmlElement *array_xml = config.FirstChildElement("array"); array_xml;
+	for (tinyxml2::XMLElement *array_xml = config.FirstChildElement("array"); array_xml;
 	     array_xml = array_xml->NextSiblingElement("array")) {
 		if (tactile->array_) {
 			CONSOLE_BRIDGE_logWarn("Only a single array element is allowed for a tactile sensor");
@@ -208,16 +208,15 @@ SensorMap parseSensorsFromParam(const std::string &param)
 
 SensorMap parseSensors(const std::string &xml_string)
 {
-	TiXmlDocument xml_doc;
-	xml_doc.Parse(xml_string.c_str());
-	if (xml_doc.Error())
-		throw std::runtime_error(std::string("Could not parse the xml document: ") + xml_doc.ErrorDesc());
+	tinyxml2::XMLDocument xml_doc;
+	if (xml_doc.Parse(xml_string.c_str()) != tinyxml2::XML_SUCCESS)
+		throw std::runtime_error(std::string("Could not parse the xml document: ") + xml_doc.ErrorStr());
 	return parseSensors(xml_doc);
 }
 
-SensorMap parseSensors(TiXmlDocument &urdf_xml)
+SensorMap parseSensors(tinyxml2::XMLDocument &urdf_xml)
 {
-	TiXmlElement *robot_xml = urdf_xml.FirstChildElement("robot");
+	tinyxml2::XMLElement *robot_xml = urdf_xml.FirstChildElement("robot");
 	if (!robot_xml) {
 		CONSOLE_BRIDGE_logError("Could not find the 'robot' element in the URDF");
 		return SensorMap();
@@ -226,9 +225,9 @@ SensorMap parseSensors(TiXmlDocument &urdf_xml)
 	TactileSensorParser parser;
 	SensorMap results;
 	// Get all sensor elements
-	for (TiXmlElement *sensor_xml = robot_xml->FirstChildElement("sensor"); sensor_xml;
+	for (tinyxml2::XMLElement *sensor_xml = robot_xml->FirstChildElement("sensor"); sensor_xml;
 	     sensor_xml = sensor_xml->NextSiblingElement("sensor")) {
-		if (TiXmlElement *tactile_xml = sensor_xml->FirstChildElement("tactile")) {
+		if (tinyxml2::XMLElement *tactile_xml = sensor_xml->FirstChildElement("tactile")) {
 			if (TactileSensor *sensor = parser.parse(*tactile_xml)) {
 				auto res = results.insert(make_pair(sensor->name_, sensor));
 				if (!res.second)

--- a/urdf_tactile/src/taxel_info_iterator.cpp
+++ b/urdf_tactile/src/taxel_info_iterator.cpp
@@ -53,9 +53,15 @@ urdf::Pose compose(const urdf::Pose &a, const urdf::Pose &b)
 /******************************************************************************
  * common interface class TaxelInfoIteratorI for implementations
  ******************************************************************************/
-class TaxelInfoIteratorI : public std::iterator<std::random_access_iterator_tag, TaxelInfo>
+class TaxelInfoIteratorI
 {
 public:
+	using iterator_category = std::random_access_iterator_tag;
+	using value_type = TaxelInfo;
+	using difference_type = std::ptrdiff_t;
+	using pointer = TaxelInfo *;
+	using reference = TaxelInfo &;
+
 	TaxelInfoIteratorI(const TactileSensorConstSharedPtr &sensor) : sensor(sensor) {}
 	virtual TaxelInfoIteratorIPtr clone() const = 0;
 	virtual ~TaxelInfoIteratorI() {}

--- a/urdf_tactile/src/utils.cpp
+++ b/urdf_tactile/src/utils.cpp
@@ -41,7 +41,7 @@
 namespace {
 using namespace urdf;
 
-bool parseSphere(Sphere &s, TiXmlElement *c)
+bool parseSphere(Sphere &s, tinyxml2::XMLElement *c)
 {
 	s.clear();
 
@@ -63,7 +63,7 @@ bool parseSphere(Sphere &s, TiXmlElement *c)
 	return true;
 }
 
-bool parseBox(Box &b, TiXmlElement *c)
+bool parseBox(Box &b, tinyxml2::XMLElement *c)
 {
 	b.clear();
 
@@ -82,7 +82,7 @@ bool parseBox(Box &b, TiXmlElement *c)
 	return true;
 }
 
-bool parseCylinder(Cylinder &y, TiXmlElement *c)
+bool parseCylinder(Cylinder &y, tinyxml2::XMLElement *c)
 {
 	y.clear();
 
@@ -113,7 +113,7 @@ bool parseCylinder(Cylinder &y, TiXmlElement *c)
 	return true;
 }
 
-bool parseMesh(Mesh &m, TiXmlElement *c)
+bool parseMesh(Mesh &m, tinyxml2::XMLElement *c)
 {
 	m.clear();
 
@@ -143,41 +143,41 @@ bool parseMesh(Mesh &m, TiXmlElement *c)
 namespace urdf {
 namespace tactile {
 
-GeometrySharedPtr parseGeometry(TiXmlElement *g)
+GeometrySharedPtr parseGeometry(tinyxml2::XMLElement *g)
 {
 	GeometrySharedPtr geom;
 	if (!g)
 		return geom;
 
-	TiXmlElement *shape = g->FirstChildElement();
+	tinyxml2::XMLElement *shape = g->FirstChildElement();
 	if (!shape) {
 		CONSOLE_BRIDGE_logError("Geometry tag contains no child element.");
 		return geom;
 	}
 
-	std::string type_name = shape->ValueStr();
-	if (type_name == "sphere") {
+	const char *type_name = shape->Value();
+	if (strcmp(type_name, "sphere") == 0) {
 		Sphere *s = new Sphere();
 		geom.reset(s);
 		if (parseSphere(*s, shape))
 			return geom;
-	} else if (type_name == "box") {
+	} else if (strcmp(type_name, "box") == 0) {
 		Box *b = new Box();
 		geom.reset(b);
 		if (parseBox(*b, shape))
 			return geom;
-	} else if (type_name == "cylinder") {
+	} else if (strcmp(type_name, "cylinder") == 0) {
 		Cylinder *c = new Cylinder();
 		geom.reset(c);
 		if (parseCylinder(*c, shape))
 			return geom;
-	} else if (type_name == "mesh") {
+	} else if (strcmp(type_name, "mesh") == 0) {
 		Mesh *m = new Mesh();
 		geom.reset(m);
 		if (parseMesh(*m, shape))
 			return geom;
 	} else {
-		CONSOLE_BRIDGE_logError("Unknown geometry type '%s'", type_name.c_str());
+		CONSOLE_BRIDGE_logError("Unknown geometry type '%s'", type_name);
 		return geom;
 	}
 

--- a/urdf_tactile/src/utils.h
+++ b/urdf_tactile/src/utils.h
@@ -41,7 +41,7 @@
 #include <urdf_model/utils.h>
 #include <urdf_model/types.h>
 #include <urdf_model/link.h>
-#include <tinyxml.h>
+#include <tinyxml2.h>
 
 namespace urdf {
 namespace tactile {
@@ -68,7 +68,7 @@ inline unsigned int parseAttribute<unsigned int>(const char* value)
 }
 
 template <typename T>
-T parseAttribute(const TiXmlElement& tag, const char* attr, const T* default_value = nullptr)
+T parseAttribute(const tinyxml2::XMLElement& tag, const char* attr, const T* default_value = nullptr)
 {
 	const char* value = tag.Attribute(attr);
 	if (!value) {
@@ -85,7 +85,7 @@ T parseAttribute(const TiXmlElement& tag, const char* attr, const T* default_val
 	}
 }
 
-urdf::GeometrySharedPtr parseGeometry(TiXmlElement* g);
+urdf::GeometrySharedPtr parseGeometry(tinyxml2::XMLElement* g);
 
 }  // namespace tactile
 }  // namespace urdf

--- a/urdf_tactile/test/parser.cpp
+++ b/urdf_tactile/test/parser.cpp
@@ -9,16 +9,15 @@ using namespace urdf::tactile;
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
-static std::shared_ptr<TiXmlDocument> loadFromFile(const std::string &path)
+static std::shared_ptr<tinyxml2::XMLDocument> loadFromFile(const std::string &path)
 {
 	std::ifstream stream(path.c_str());
 	BOOST_REQUIRE_MESSAGE(stream, "failed to open file: " + path);
 
 	std::string xml_str((std::istreambuf_iterator<char>(stream)), std::istreambuf_iterator<char>());
 
-	std::shared_ptr<TiXmlDocument> xml_doc(new TiXmlDocument());
-	xml_doc->Parse(xml_str.c_str());
-	BOOST_REQUIRE(!xml_doc->Error());
+	std::shared_ptr<tinyxml2::XMLDocument> xml_doc(new tinyxml2::XMLDocument());
+	BOOST_REQUIRE(xml_doc->Parse(xml_str.c_str()) == tinyxml2::XML_SUCCESS);
 
 	return xml_doc;
 }
@@ -42,10 +41,10 @@ BOOST_AUTO_TEST_CASE(test_pluginlib_parsing)
 	check_sensor_map(parseSensorsFromFile("tactile.urdf"));
 }
 
-void change_and_check_order_mode(const TactileSensorParser &parser, TiXmlElement &tactile_xml, const char *pcMode,
-                                 TactileArray::DataOrder mode)
+void change_and_check_order_mode(const TactileSensorParser &parser, tinyxml2::XMLElement &tactile_xml,
+                                 const char *pcMode, TactileArray::DataOrder mode)
 {
-	TiXmlElement *array_xml = tactile_xml.FirstChildElement("array");
+	tinyxml2::XMLElement *array_xml = tactile_xml.FirstChildElement("array");
 	array_xml->SetAttribute("order", pcMode);
 	TactileSensorSharedPtr tactile(parser.parse(tactile_xml));
 	BOOST_REQUIRE(tactile);
@@ -55,10 +54,10 @@ void change_and_check_order_mode(const TactileSensorParser &parser, TiXmlElement
 BOOST_AUTO_TEST_CASE(test_tactile_array)
 {
 	TactileSensorParser parser;
-	std::shared_ptr<TiXmlDocument> root = loadFromFile("tactile.urdf");
+	std::shared_ptr<tinyxml2::XMLDocument> root = loadFromFile("tactile.urdf");
 	BOOST_REQUIRE(root);
 
-	TiXmlElement *tactile_xml = root->RootElement()->FirstChildElement("sensor")->FirstChildElement("tactile");
+	tinyxml2::XMLElement *tactile_xml = root->RootElement()->FirstChildElement("sensor")->FirstChildElement("tactile");
 	BOOST_REQUIRE(tactile_xml);
 
 	TactileSensorSharedPtr tactile(parser.parse(*tactile_xml));
@@ -71,17 +70,17 @@ BOOST_AUTO_TEST_CASE(test_tactile_array)
 	change_and_check_order_mode(parser, *tactile_xml, "row-major", TactileArray::ROWMAJOR);
 	change_and_check_order_mode(parser, *tactile_xml, "col-major", TactileArray::COLUMNMAJOR);
 
-	TiXmlElement *array_xml = tactile_xml->FirstChildElement("array");
+	tinyxml2::XMLElement *array_xml = tactile_xml->FirstChildElement("array");
 
 	// missing spacing attribute defaults to size
-	array_xml->RemoveAttribute("spacing");
+	array_xml->DeleteAttribute("spacing");
 	tactile.reset(parser.parse(*tactile_xml));
 	BOOST_REQUIRE(tactile);
 	BOOST_CHECK(tactile->array_->spacing.x == tactile->array_->size.x);
 	BOOST_CHECK(tactile->array_->spacing.y == tactile->array_->size.y);
 
 	// missing offset attribute defaults to zero
-	array_xml->RemoveAttribute("offset");
+	array_xml->DeleteAttribute("offset");
 	tactile.reset(parser.parse(*tactile_xml));
 	BOOST_REQUIRE(tactile);
 	BOOST_CHECK(tactile->array_->offset.x == 0);


### PR DESCRIPTION
Surprisingly, the Noble CI image still uses urdfdom 3 (and thus fails), while the [ROS builder uses urdfdom 4 on Noble](https://github.com/ubi-agni/ros-builder-action/actions/runs/21787046068).
@guihomework: you will need this for Ubuntu 24.04